### PR TITLE
fix: truncate worktree database names to respect 63-char limit

### DIFF
--- a/internal/presets/laravel.go
+++ b/internal/presets/laravel.go
@@ -23,7 +23,7 @@ func NewLaravel() *Laravel {
 				{Name: "php.laravel", Args: []string{"key:generate", "--show", "--no-interaction"}, StoreAs: "AppKey", Condition: map[string]interface{}{"env_file_missing": "APP_KEY"}},
 				{Name: "env.write", Key: "APP_KEY", Value: "{{ .AppKey }}", Condition: map[string]interface{}{"env_file_missing": "APP_KEY"}},
 				{Name: "db.create", Condition: map[string]interface{}{"env_file_contains": map[string]interface{}{"file": ".env", "key": "DB_CONNECTION"}}},
-				{Name: "env.write", Key: "DB_DATABASE", Value: "{{ .SanitizedSiteName }}_{{ .DbSuffix }}", Condition: map[string]interface{}{"env_file_contains": map[string]interface{}{"file": ".env", "key": "DB_CONNECTION"}}},
+				{Name: "env.write", Key: "DB_DATABASE", Value: "{{ .DatabaseName }}", Condition: map[string]interface{}{"env_file_contains": map[string]interface{}{"file": ".env", "key": "DB_CONNECTION"}}},
 				{Name: "node.npm", Args: []string{"ci"}, Condition: map[string]interface{}{"file_exists": "package-lock.json"}},
 				{Name: "php.laravel", Args: []string{"migrate:fresh", "--seed", "--no-interaction"}},
 				{Name: "node.npm", Args: []string{"run", "build"}, Condition: map[string]interface{}{"file_exists": "package-lock.json"}},

--- a/internal/presets/presets_test.go
+++ b/internal/presets/presets_test.go
@@ -87,7 +87,7 @@ func TestLaravelPreset_DefaultSteps(t *testing.T) {
 
 	assert.Equal(t, "env.write", steps[6].Name)
 	assert.Equal(t, "DB_DATABASE", steps[6].Key)
-	assert.Equal(t, "{{ .SanitizedSiteName }}_{{ .DbSuffix }}", steps[6].Value)
+	assert.Equal(t, "{{ .DatabaseName }}", steps[6].Value)
 
 	assert.Equal(t, "node.npm", steps[7].Name)
 	assert.Equal(t, []string{"ci"}, steps[7].Args)

--- a/internal/scaffold/integration_test.go
+++ b/internal/scaffold/integration_test.go
@@ -410,7 +410,7 @@ APP_NAME=some-feature
 		actualDbName := createCalls[0]
 		assert.True(t, strings.HasPrefix(actualDbName, "some_feature_"), "Database should be created with sanitized name (underscores)")
 
-		writeStep, err := steps.Create("env.write", config.StepConfig{Key: "DB_DATABASE", Value: "{{ .SanitizedSiteName }}_{{ .DbSuffix }}"})
+		writeStep, err := steps.Create("env.write", config.StepConfig{Key: "DB_DATABASE", Value: "{{ .DatabaseName }}"})
 		require.NoError(t, err)
 		err = writeStep.Run(ctx, types.StepOptions{Verbose: false})
 		require.NoError(t, err)

--- a/internal/scaffold/steps/db.go
+++ b/internal/scaffold/steps/db.go
@@ -171,7 +171,7 @@ func (s *DbCreateStep) createWithRetry(ctx *types.ScaffoldContext, engine string
 		existingSuffix := ctx.GetDbSuffix()
 		if existingSuffix != "" {
 			suffix = existingSuffix
-			dbName = fmt.Sprintf("%s_%s", words.SanitizeSiteName(siteName), suffix)
+			dbName = words.BuildDatabaseName(siteName, suffix, 0)
 		} else {
 			dbName = words.GenerateDatabaseName(siteName, 0)
 			suffix = words.ExtractSuffix(dbName)

--- a/internal/scaffold/template/template_test.go
+++ b/internal/scaffold/template/template_test.go
@@ -99,6 +99,18 @@ func TestReplaceTemplateVars(t *testing.T) {
 			expected: "my_app_swift_runner",
 		},
 		{
+			name:     "DatabaseName template variable",
+			input:    "{{ .DatabaseName }}",
+			ctx:      &types.ScaffoldContext{SiteName: "myapp", DbSuffix: "swift_runner"},
+			expected: "myapp_swift_runner",
+		},
+		{
+			name:     "DatabaseName truncates long site names to 63 chars",
+			input:    "{{ .DatabaseName }}",
+			ctx:      &types.ScaffoldContext{SiteName: "hotfix/track-collection-reflection-exception-handling", DbSuffix: "stable_resolver"},
+			expected: "hotfix_track_collection_reflection_exception_ha_stable_resolver",
+		},
+		{
 			name:     "SanitizedSiteName removes hyphens",
 			input:    "{{ .SanitizedSiteName }}",
 			ctx:      &types.ScaffoldContext{SiteName: "feature-auth-system"},

--- a/internal/scaffold/types/types.go
+++ b/internal/scaffold/types/types.go
@@ -356,19 +356,43 @@ func (ctx *ScaffoldContext) GetDbSuffix() string {
 func (ctx *ScaffoldContext) SnapshotForTemplate() map[string]string {
 	ctx.mu.RLock()
 	defer ctx.mu.RUnlock()
+
+	sanitized := sanitizeSiteName(ctx.SiteName)
+
+	// Build a truncated database name that respects identifier limits.
+	var dbName string
+	if ctx.DbSuffix != "" {
+		dbName = buildDatabaseName(sanitized, ctx.DbSuffix, maxDbNameLength)
+	}
+
 	snapshot := map[string]string{
 		"Path":              ctx.Path,
 		"RepoPath":          ctx.RepoPath,
 		"RepoName":          ctx.RepoName,
 		"SiteName":          ctx.SiteName,
-		"SanitizedSiteName": sanitizeSiteName(ctx.SiteName),
+		"SanitizedSiteName": sanitized,
 		"Branch":            ctx.Branch,
 		"DbSuffix":          ctx.DbSuffix,
+		"DatabaseName":      dbName,
 	}
 	for k, v := range ctx.Vars {
 		snapshot[k] = v
 	}
 	return snapshot
+}
+
+const maxDbNameLength = 63
+
+func buildDatabaseName(sanitized string, suffix string, maxLength int) string {
+	maxSiteLen := maxLength - len(suffix) - 1
+	if maxSiteLen < 1 {
+		maxSiteLen = 1
+	}
+	if len(sanitized) > maxSiteLen {
+		sanitized = sanitized[:maxSiteLen]
+		sanitized = strings.TrimRight(sanitized, "_")
+	}
+	return sanitized + "_" + suffix
 }
 
 func sanitizeSiteName(name string) string {

--- a/internal/scaffold/words/words.go
+++ b/internal/scaffold/words/words.go
@@ -60,14 +60,20 @@ func SanitizeSiteName(name string) string {
 }
 
 func GenerateDatabaseName(siteName string, maxLength int) string {
+	return BuildDatabaseName(siteName, GenerateSuffix(), maxLength)
+}
+
+func BuildDatabaseName(siteName string, suffix string, maxLength int) string {
 	if maxLength == 0 {
 		maxLength = MaxDbNameLength
 	}
 
 	sanitized := SanitizeSiteName(siteName)
-	suffix := GenerateSuffix()
 
 	maxSiteLen := maxLength - len(suffix) - 1
+	if maxSiteLen < 1 {
+		maxSiteLen = 1
+	}
 	if len(sanitized) > maxSiteLen {
 		sanitized = sanitized[:maxSiteLen]
 		sanitized = strings.TrimRight(sanitized, "_")

--- a/internal/scaffold/words/words_test.go
+++ b/internal/scaffold/words/words_test.go
@@ -192,6 +192,42 @@ func TestGenerateDatabaseName(t *testing.T) {
 	})
 }
 
+func TestBuildDatabaseName(t *testing.T) {
+	t.Run("short name fits within limit", func(t *testing.T) {
+		name := BuildDatabaseName("myapp", "stable_resolver", 0)
+		if name != "myapp_stable_resolver" {
+			t.Errorf("expected myapp_stable_resolver, got %s", name)
+		}
+	})
+
+	t.Run("truncates long site name to fit 63 char default", func(t *testing.T) {
+		name := BuildDatabaseName("hotfix/track-collection-reflection-exception-handling", "stable_resolver", 0)
+		if len(name) > 63 {
+			t.Errorf("name should not exceed 63 characters, got %d: %s", len(name), name)
+		}
+		if !strings.HasSuffix(name, "_stable_resolver") {
+			t.Errorf("name should end with suffix, got %s", name)
+		}
+	})
+
+	t.Run("respects custom max length", func(t *testing.T) {
+		name := BuildDatabaseName("a_very_long_site_name_here", "stable_resolver", 30)
+		if len(name) > 30 {
+			t.Errorf("name should not exceed 30 characters, got %d: %s", len(name), name)
+		}
+	})
+
+	t.Run("does not end with trailing underscore after truncation", func(t *testing.T) {
+		// Construct a name where truncation would land on an underscore
+		name := BuildDatabaseName("my_app_feature_x", "stable_resolver", 30)
+		parts := strings.SplitN(name, "_stable_resolver", 2)
+		sitePart := parts[0]
+		if strings.HasSuffix(sitePart, "_") {
+			t.Errorf("site name part should not end with underscore, got %s", sitePart)
+		}
+	})
+}
+
 func TestMaxLengthEnforcement(t *testing.T) {
 	t.Run("respects PostgreSQL limit of 63", func(t *testing.T) {
 		name := GenerateDatabaseName("verylongsitenamethatdefinitelyexceedslimitsbyalot", 0)


### PR DESCRIPTION
## Summary

- Long branch names (e.g., `hotfix/track-collection-reflection-exception`) produced database identifiers over 64 characters, causing `SQLSTATE[42000]: Identifier name is too long` errors in MySQL
- Extract `BuildDatabaseName(siteName, suffix, maxLength)` to ensure the site name is truncated so the full `name_suffix` stays within the 63-char limit
- Add `{{ .DatabaseName }}` template variable for consistent truncation in env.write steps

## Test plan

- [x] All existing tests pass
- [x] New tests for `BuildDatabaseName` with long names, custom limits, and trailing underscore trimming
- [x] New template test verifying `{{ .DatabaseName }}` truncates correctly
- [ ] Manual test: create a worktree with a long branch name and verify the database is created successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)