### PR TITLE
fix: strip ANSI escape codes from captured APP_KEY

### DIFF
--- a/internal/presets/laravel.go
+++ b/internal/presets/laravel.go
@@ -20,7 +20,7 @@ func NewLaravel() *Laravel {
 				{Name: "php.composer", Args: []string{"install"}, Condition: map[string]interface{}{"file_exists": "composer.lock"}},
 				{Name: "php.composer", Args: []string{"update"}, Condition: map[string]interface{}{"not": map[string]interface{}{"file_exists": "composer.lock"}}},
 				{Name: "file.copy", From: ".env.example", To: ".env"},
-				{Name: "php.laravel", Args: []string{"key:generate", "--show", "--no-interaction"}, StoreAs: "AppKey", Condition: map[string]interface{}{"env_file_missing": "APP_KEY"}},
+				{Name: "php.laravel", Args: []string{"key:generate", "--show", "--no-interaction", "--no-ansi"}, StoreAs: "AppKey", Condition: map[string]interface{}{"env_file_missing": "APP_KEY"}},
 				{Name: "env.write", Key: "APP_KEY", Value: "{{ .AppKey }}", Condition: map[string]interface{}{"env_file_missing": "APP_KEY"}},
 				{Name: "db.create", Condition: map[string]interface{}{"env_file_contains": map[string]interface{}{"file": ".env", "key": "DB_CONNECTION"}}},
 				{Name: "env.write", Key: "DB_DATABASE", Value: "{{ .DatabaseName }}", Condition: map[string]interface{}{"env_file_contains": map[string]interface{}{"file": ".env", "key": "DB_CONNECTION"}}},

--- a/internal/presets/presets_test.go
+++ b/internal/presets/presets_test.go
@@ -76,7 +76,7 @@ func TestLaravelPreset_DefaultSteps(t *testing.T) {
 	assert.Equal(t, ".env", steps[2].To)
 
 	assert.Equal(t, "php.laravel", steps[3].Name)
-	assert.Equal(t, []string{"key:generate", "--show", "--no-interaction"}, steps[3].Args)
+	assert.Equal(t, []string{"key:generate", "--show", "--no-interaction", "--no-ansi"}, steps[3].Args)
 	assert.Equal(t, "AppKey", steps[3].StoreAs)
 
 	assert.Equal(t, "env.write", steps[4].Name)

--- a/internal/presets/tars.go
+++ b/internal/presets/tars.go
@@ -19,7 +19,7 @@ func NewLaravelSharedDB() *LaravelSharedDB {
 				{Name: "php.composer", Args: []string{"install"}, Condition: map[string]interface{}{"file_exists": "composer.lock"}},
 				{Name: "php.composer", Args: []string{"update"}, Condition: map[string]interface{}{"not": map[string]interface{}{"file_exists": "composer.lock"}}},
 				{Name: "file.copy", From: ".env.example", To: ".env"},
-				{Name: "php.laravel.artisan", Args: []string{"key:generate", "--no-interaction"}, Condition: map[string]interface{}{"env_file_missing": "APP_KEY"}},
+				{Name: "php.laravel.artisan", Args: []string{"key:generate", "--no-interaction", "--no-ansi"}, Condition: map[string]interface{}{"env_file_missing": "APP_KEY"}},
 				// NO db.create - shared database across all worktrees
 				// NO env.write for DB_DATABASE - preserve the shared database name
 				{Name: "node.npm", Args: []string{"ci"}, Condition: map[string]interface{}{"file_exists": "package-lock.json"}},

--- a/internal/scaffold/steps/binary.go
+++ b/internal/scaffold/steps/binary.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os/exec"
+	"regexp"
 	"strings"
 
 	"github.com/naoray/anvil/internal/config"
@@ -11,6 +12,9 @@ import (
 	"github.com/naoray/anvil/internal/scaffold/template"
 	"github.com/naoray/anvil/internal/scaffold/types"
 )
+
+// ansiPattern matches ANSI escape sequences (colors, cursor movement, etc.)
+var ansiPattern = regexp.MustCompile(`\x1b\[[0-9;]*[a-zA-Z]`)
 
 type BinaryStep struct {
 	name      string
@@ -96,7 +100,8 @@ func (s *BinaryStep) Run(ctx *types.ScaffoldContext, opts types.StepOptions) err
 	}
 
 	if s.storeAs != "" {
-		ctx.SetVar(s.storeAs, strings.TrimSpace(string(output)))
+		cleaned := ansiPattern.ReplaceAllString(string(output), "")
+		ctx.SetVar(s.storeAs, strings.TrimSpace(cleaned))
 		if opts.Verbose {
 			fmt.Printf("  Stored output as %s\n", s.storeAs)
 		}

--- a/internal/scaffold/steps/binary_test.go
+++ b/internal/scaffold/steps/binary_test.go
@@ -669,6 +669,27 @@ func TestBinaryStep_OutputCapture(t *testing.T) {
 		assert.Equal(t, "new value", ctx.GetVar("MyVar"))
 	})
 
+	t.Run("strips ANSI escape codes from captured output", func(t *testing.T) {
+		// Simulate output with ANSI color codes (e.g., \033[33m yellow \033[39m reset)
+		step := NewBinaryStep("test.printf", "printf", []string{"\033[33mbase64:abc123def456\033[39m"}, "AppKey")
+		ctx := &types.ScaffoldContext{WorktreePath: t.TempDir()}
+
+		err := step.Run(ctx, types.StepOptions{})
+
+		assert.NoError(t, err)
+		assert.Equal(t, "base64:abc123def456", ctx.GetVar("AppKey"))
+	})
+
+	t.Run("strips multiple ANSI escape codes from captured output", func(t *testing.T) {
+		step := NewBinaryStep("test.printf", "printf", []string{"\033[1m\033[33mbase64:key\033[39m\033[0m"}, "AppKey")
+		ctx := &types.ScaffoldContext{WorktreePath: t.TempDir()}
+
+		err := step.Run(ctx, types.StepOptions{})
+
+		assert.NoError(t, err)
+		assert.Equal(t, "base64:key", ctx.GetVar("AppKey"))
+	})
+
 	t.Run("creates step via Create with store_as", func(t *testing.T) {
 		step, err := Create("php", config.StepConfig{
 			Args:    []string{"-r", "echo 'hello';"},


### PR DESCRIPTION
## Summary
- Strip ANSI escape codes from all `StoreAs` captured output in binary steps, preventing malformed APP_KEY values with embedded color codes like `[33m` and `[39m`
- Add `--no-ansi` flag to `key:generate` artisan commands in both Laravel and LaravelSharedDB presets as first line of defense
- Add tests verifying ANSI stripping works with single and multiple escape sequences

## Test plan
- [x] All existing tests pass
- [x] New tests verify ANSI codes are stripped from captured output
- [ ] Manually scaffold a worktree and verify APP_KEY is clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)