### PR TITLE
Audit: Remove dead code

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -523,61 +523,6 @@ func CreateGlobalConfig(config *GlobalConfig) error {
 	return nil
 }
 
-// WorktreeConfig represents worktree-local configuration
-type WorktreeConfig struct {
-	DbSuffix string `mapstructure:"db_suffix"`
-}
-
-// ReadWorktreeConfig reads worktree-local configuration from anvil.yaml
-func ReadWorktreeConfig(worktreePath string) (*WorktreeConfig, error) {
-	configPath := filepath.Join(worktreePath, "anvil.yaml")
-
-	if _, err := os.Stat(configPath); os.IsNotExist(err) {
-		return &WorktreeConfig{}, nil
-	}
-
-	v := viper.New()
-	v.SetConfigName("anvil")
-	v.SetConfigType("yaml")
-	v.AddConfigPath(worktreePath)
-
-	if err := v.ReadInConfig(); err != nil {
-		return nil, fmt.Errorf("reading worktree config: %w", err)
-	}
-
-	var config WorktreeConfig
-	if err := v.Unmarshal(&config); err != nil {
-		return nil, fmt.Errorf("parsing worktree config: %w", err)
-	}
-
-	return &config, nil
-}
-
-// WriteWorktreeConfig writes worktree-local configuration to anvil.yaml
-func WriteWorktreeConfig(worktreePath string, data map[string]string) error {
-	v := viper.New()
-	v.SetConfigName("anvil")
-	v.SetConfigType("yaml")
-	v.AddConfigPath(worktreePath)
-
-	dataMap := make(map[string]interface{})
-	for k, v := range data {
-		dataMap[k] = v
-	}
-
-	if err := v.MergeConfigMap(dataMap); err != nil {
-		return fmt.Errorf("merging worktree config: %w", err)
-	}
-
-	configPath := filepath.Join(worktreePath, "anvil.yaml")
-
-	if err := v.WriteConfigAs(configPath); err != nil {
-		return fmt.Errorf("writing worktree config: %w", err)
-	}
-
-	return nil
-}
-
 // SaveGlobalConfig saves the global configuration to anvil.yaml
 func SaveGlobalConfig(config *GlobalConfig) error {
 	configDir, err := GetGlobalConfigDir()

--- a/internal/git/worktree.go
+++ b/internal/git/worktree.go
@@ -262,16 +262,6 @@ func DeleteBranch(gitDir, branch string, force bool) error {
 	return nil
 }
 
-// PruneWorktrees prunes stale worktree refs from the repository
-func PruneWorktrees(gitDir string) error {
-	cmd := exec.Command("git", "-C", gitDir, "worktree", "prune")
-	output, err := cmd.CombinedOutput()
-	if err != nil {
-		return fmt.Errorf("git worktree prune failed: %w\n%s", err, string(output))
-	}
-	return nil
-}
-
 // ListBranches lists all local branches in the repository (excluding current branch)
 func ListBranches(gitDir string) ([]string, error) {
 	cmd := exec.Command("git", "-C", gitDir, "branch", "--list")

--- a/internal/ui/interactive.go
+++ b/internal/ui/interactive.go
@@ -156,37 +156,6 @@ func Confirm(message string) (bool, error) {
 	return confirmed, nil
 }
 
-func PromptRepoURL() (string, error) {
-	var repo string
-
-	form := huh.NewForm(
-		huh.NewGroup(
-			huh.NewInput().
-				Title("Repository").
-				Description("GitHub URL or owner/repo format").
-				Placeholder("owner/repo or git@github.com:owner/repo.git").
-				Value(&repo).
-				Validate(validateRepoURL),
-		),
-	).WithTheme(huh.ThemeCatppuccin())
-
-	if err := form.Run(); err != nil {
-		return "", NormalizeAbort(err)
-	}
-
-	return repo, nil
-}
-
-func validateRepoURL(s string) error {
-	if s == "" {
-		return fmt.Errorf("repository URL cannot be empty")
-	}
-	if len(s) < 3 {
-		return fmt.Errorf("repository URL must be at least 3 characters")
-	}
-	return nil
-}
-
 func SelectWorktreeToRemove(worktrees []git.Worktree) (*git.Worktree, error) {
 	var removable []git.Worktree
 	for _, wt := range worktrees {

--- a/internal/ui/table.go
+++ b/internal/ui/table.go
@@ -11,22 +11,6 @@ import (
 	"github.com/naoray/anvil/internal/git"
 )
 
-func RenderTable(headers []string, rows [][]string) string {
-	t := table.New().
-		Border(lipgloss.NormalBorder()).
-		BorderStyle(lipgloss.NewStyle().Foreground(Primary)).
-		Headers(headers...).
-		StyleFunc(func(row, col int) lipgloss.Style {
-			return lipgloss.NewStyle().Padding(0, 1)
-		})
-
-	for _, row := range rows {
-		t.Row(row...)
-	}
-
-	return t.String()
-}
-
 func RenderStatusTable(rows [][]string) string {
 	t := table.New().
 		Border(lipgloss.NormalBorder()).


### PR DESCRIPTION
## Summary
- Removed unused functions: `ReadWorktreeConfig`, `WriteWorktreeConfig`, `WorktreeConfig` type (config)
- Removed unused function: `PruneWorktrees` (git/worktree)
- Removed unused functions: `DirectoryExists`, `EnsureDirectory`, `JoinPath` (presets/manager)
- Removed unused functions: `PromptRepoURL`, `validateRepoURL` (ui/interactive)
- Removed unused function: `RenderTable` (ui/table)
- Fixed pre-existing gofmt alignment issue in `styles.go`

## Audit Type
Dead Code — full codebase sweep using `deadcode -test ./...`

All tests pass, golangci-lint clean, go vet clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)