### PR TITLE
release: prepare v1.8.0

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -13,13 +13,26 @@ jobs:
         with:
           ref: main
 
+      - name: Check for existing release heading
+        id: heading
+        env:
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+        run: |
+          if grep -Fq -- "## [$RELEASE_TAG]" CHANGELOG.md; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Update Changelog
+        if: steps.heading.outputs.exists == 'false'
         uses: stefanzweifel/changelog-updater-action@v1
         with:
           latest-version: ${{ github.event.release.name }}
           release-notes: ${{ github.event.release.body }}
 
       - name: Commit updated CHANGELOG
+        if: steps.heading.outputs.exists == 'false'
         uses: stefanzweifel/git-auto-commit-action@v7
         with:
           branch: main

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,7 +60,7 @@ jobs:
       - name: Get version
         id: version
         shell: bash
-        run: echo "VERSION=${GITHUB_REF#refs/tags/v}" >> $GITHUB_OUTPUT
+        run: echo "VERSION=${GITHUB_REF#refs/tags/v}" >> "$GITHUB_OUTPUT"
 
       - name: Build binary
         shell: bash
@@ -68,27 +68,42 @@ jobs:
           CGO_ENABLED: 0
           GOOS: ${{ matrix.goos }}
           GOARCH: ${{ matrix.goarch }}
+          VERSION: ${{ steps.version.outputs.VERSION }}
+          TARGET: ${{ matrix.target }}
+          BINARY_EXT: ${{ matrix.binary_ext }}
         run: |
           COMMIT=$(git rev-parse --short HEAD)
           DATE=$(date -u +%Y-%m-%dT%H:%M:%SZ)
-          go build -trimpath -ldflags "-X main.Version=${{ steps.version.outputs.VERSION }} -X main.Commit=$COMMIT -X main.BuildDate=$DATE" \
-            -o anvil-${{ steps.version.outputs.VERSION }}-${{ matrix.target }}${{ matrix.binary_ext }} ./cmd/anvil
+          go build -trimpath -ldflags "-X main.Version=$VERSION -X main.Commit=$COMMIT -X main.BuildDate=$DATE" \
+            -o "anvil-$VERSION-$TARGET$BINARY_EXT" ./cmd/anvil
 
       - name: Create archive (tar.gz)
         if: matrix.zip_extension == 'tar.gz'
-        run: tar -czf anvil-${{ steps.version.outputs.VERSION }}-${{ matrix.target }}.${{ matrix.zip_extension }} anvil-${{ steps.version.outputs.VERSION }}-${{ matrix.target }}${{ matrix.binary_ext }}
+        env:
+          VERSION: ${{ steps.version.outputs.VERSION }}
+          TARGET: ${{ matrix.target }}
+          ZIP_EXTENSION: ${{ matrix.zip_extension }}
+          BINARY_EXT: ${{ matrix.binary_ext }}
+        run: tar -czf "anvil-$VERSION-$TARGET.$ZIP_EXTENSION" "anvil-$VERSION-$TARGET$BINARY_EXT"
 
       - name: Create archive (zip)
         if: matrix.zip_extension == 'zip'
         shell: pwsh
+        env:
+          VERSION: ${{ steps.version.outputs.VERSION }}
+          TARGET: ${{ matrix.target }}
         run: |
-          $version = $env:GITHUB_REF -replace 'refs/tags/v', ''
-          $target = "${{ matrix.target }}"
+          $version = $env:VERSION
+          $target = $env:TARGET
           7z a "anvil-$version-$target.zip" "anvil-$version-$target.exe"
 
       - name: Generate checksum
         shell: bash
-        run: sha256sum anvil-${{ steps.version.outputs.VERSION }}-${{ matrix.target }}.${{ matrix.zip_extension }} > anvil-${{ steps.version.outputs.VERSION }}-${{ matrix.target }}.sha256
+        env:
+          VERSION: ${{ steps.version.outputs.VERSION }}
+          TARGET: ${{ matrix.target }}
+          ZIP_EXTENSION: ${{ matrix.zip_extension }}
+        run: sha256sum "anvil-$VERSION-$TARGET.$ZIP_EXTENSION" > "anvil-$VERSION-$TARGET.sha256"
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4
@@ -113,37 +128,31 @@ jobs:
 
       - name: Get version
         id: version
-        run: echo "VERSION=${GITHUB_REF#refs/tags/v}" >> $GITHUB_OUTPUT
+        run: echo "VERSION=${GITHUB_REF#refs/tags/v}" >> "$GITHUB_OUTPUT"
 
       - name: Get previous tag
         id: previous_tag
+        env:
+          CURRENT_TAG: v${{ steps.version.outputs.VERSION }}
         run: |
-          PREVIOUS=$(git describe --tags --abbrev=0 "v${{ steps.version.outputs.VERSION }}^" 2>/dev/null || echo "")
-          echo "PREVIOUS=$PREVIOUS" >> $GITHUB_OUTPUT
-
-      - name: Get tag annotation
-        id: tag_annotation
-        run: |
-          ANNOTATION=$(git tag -l --format='%(contents)' "v${{ steps.version.outputs.VERSION }}")
-          echo "ANNOTATION<<EOF" >> $GITHUB_OUTPUT
-          echo "$ANNOTATION" >> $GITHUB_OUTPUT
-          echo "EOF" >> $GITHUB_OUTPUT
+          PREVIOUS=$(git describe --tags --abbrev=0 "${CURRENT_TAG}^" 2>/dev/null || true)
+          echo "PREVIOUS=$PREVIOUS" >> "$GITHUB_OUTPUT"
 
       - name: Build release body
         id: release_body
+        env:
+          VERSION: ${{ steps.version.outputs.VERSION }}
+          PREVIOUS: ${{ steps.previous_tag.outputs.PREVIOUS }}
+          REPOSITORY: ${{ github.repository }}
         run: |
-          PREVIOUS="${{ steps.previous_tag.outputs.PREVIOUS }}"
-          CURRENT="v${{ steps.version.outputs.VERSION }}"
-          {
-            echo "BODY<<EOF"
-            echo "${{ steps.tag_annotation.outputs.ANNOTATION }}"
-            if [ -n "$PREVIOUS" ]; then
-              echo ""
-              echo ""
-              echo "**Full changelog:** [$PREVIOUS..$CURRENT](https://github.com/${{ github.repository }}/compare/$PREVIOUS..$CURRENT)"
-            fi
-            echo "EOF"
-          } >> $GITHUB_OUTPUT
+          CURRENT="v$VERSION"
+          BODY_PATH=$(mktemp "$RUNNER_TEMP/anvil-release-body.XXXXXX")
+          git cat-file tag "$CURRENT" | sed '1,/^$/d' > "$BODY_PATH"
+          if [ -n "$PREVIOUS" ]; then
+            printf '\n\n**Full changelog:** [%s..%s](https://github.com/%s/compare/%s..%s)\n' \
+              "$PREVIOUS" "$CURRENT" "$REPOSITORY" "$PREVIOUS" "$CURRENT" >> "$BODY_PATH"
+          fi
+          echo "BODY_PATH=$BODY_PATH" >> "$GITHUB_OUTPUT"
 
       - name: Download artifacts
         uses: actions/download-artifact@v4
@@ -162,15 +171,17 @@ jobs:
         with:
           tag_name: v${{ steps.version.outputs.VERSION }}
           name: v${{ steps.version.outputs.VERSION }}
-          body: ${{ steps.release_body.outputs.BODY }}
+          body_path: ${{ steps.release_body.outputs.BODY_PATH }}
           files: release-artifacts/*
 
       - name: Trigger Homebrew formula update
         env:
           GH_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+          VERSION: ${{ steps.version.outputs.VERSION }}
+          REPOSITORY: ${{ github.repository }}
         run: |
           gh api repos/naoray/homebrew-tap/dispatches \
             --method POST \
             --field event_type=update-formula \
-            --field client_payload[version]="${{ steps.version.outputs.VERSION }}" \
-            --field client_payload[repository]="${{ github.repository }}"
+            --field "client_payload[version]=$VERSION" \
+            --field "client_payload[repository]=$REPOSITORY"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -50,7 +50,7 @@ anvil remove feature-my-feature  # When done
 |--------|----------|---------|------------|
 | Project | `<project-root>/anvil.yaml` | Project-specific settings, scaffold config, pre-flight checks | No (not in a repo) |
 | Repository | `<worktree>/anvil.yaml` | Team defaults | Yes (committed to git) |
-| Local State | `<worktree>/.anvil.local` | Runtime state (db_suffix) | No (gitignored) |
+| Local State | `<worktree>/.anvil.local` | Runtime state (`db_suffix` and database ownership records) | No (gitignored) |
 | Global | `~/.config/anvil/anvil.yaml` | User defaults | No (local machine) |
 
 ### Step Naming
@@ -89,6 +89,8 @@ Steps use simplified dot notation where the tool namespace maps to the binary:
 | 4 | Git operation failed |
 | 5 | Configuration error |
 | 6 | Scaffold step failed |
+
+**`anvil exec` exception:** `anvil exec` passes the child process's exit code through verbatim; `127` means the command was not found and `126` means it was found but could not be executed. Anvil's own resolution failures exit `1`. See README "Test Database Isolation" for the `anvil exec` and `anvil remove --keep-db` command reference.
 
 ## Testing
 
@@ -201,7 +203,7 @@ This approach ensures:
 All foundational phases (1-5) are complete. The project is in active feature development:
 - Core: worktree management, config hierarchy, scaffold system
 - Presets: Laravel, PHP, Laravel-Shared-DB
-- Commands: link, unlink, work, list, info, open, sync, remove, prune, scaffold, pull-config, repair, install, completion
+- Commands: link, unlink, work, list, info, open, sync, remove, prune, scaffold, exec, pull-config, repair, install, completion
 - Distribution: Homebrew, GitHub Releases, Go Install
 - Shell completions for worktree arguments (zsh, bash, fish, powershell)
 
@@ -257,15 +259,14 @@ When preparing a new release:
 
 1. Update CHANGELOG.md with changes since the last release
 2. Commit: `release: prepare vX.Y.Z`
-3. Tag: `git tag vX.Y.Z`
+3. Tag (annotated): `git tag -a vX.Y.Z -m "vX.Y.Z"`
 4. Push: `git push && git push origin vX.Y.Z`
-5. Create GitHub release: `gh release create vX.Y.Z --title "vX.Y.Z" --notes "..."`
-6. CI builds and uploads binaries automatically
-7. Homebrew tap updates via the "Update Changelog" workflow
+5. The tag push triggers `.github/workflows/release.yml`, which builds the binaries and creates the GitHub release automatically — do not run `gh release create`
+6. The "Update Changelog" workflow runs after the release and skips any release whose CHANGELOG section is already curated (single-writer guard)
+7. Homebrew tap updates automatically from the release workflow
 
 **Requirements:**
 - All changes committed, working directory clean
-- `gh` CLI tool installed
 - Tests and lint must pass
 
 **Version Format:** Always use `v` prefix (e.g., `v1.7.0`)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,31 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v1.8.0](https://github.com/naoray/anvil/compare/v1.7.1...v1.8.0) - 2026-07-17
+
+### Added
+
+- **Per-worktree test database** — the Laravel preset now scaffolds an isolated `role: testing` database (`<site>_<suffix>_test`, capped at 54 chars for parallel-worker headroom) alongside the application database.
+- **`anvil exec`** — run any command with the worktree's test database exported (`DB_DATABASE`, `ANVIL_TEST_DB_DATABASE`, `ANVIL_DB_DATABASE`); strictly read-only, cross-platform, child exit codes passed through (`127` not found, `126` not executable).
+- **`anvil remove --keep-db`** — remove a worktree while preserving its databases (parallel-worker databases included).
+- **Real `anvil remove --dry-run` enumeration** — dry-run now executes the cleanup selector live and prints the exact `Would drop database:` set, including parallel-worker databases.
+- **`{{ .TestDatabaseName }}`** template variable for custom scaffold steps.
+- **`databases` ownership records in `.anvil.local`** — every Anvil-created server database is recorded as `{name, engine, role}`; unknown YAML fields and unknown-role records are preserved on rewrite.
+
+### Changed
+
+- Cleanup drops the exact owned databases plus Laravel parallel-worker families for both the application and testing databases, instead of relying on suffix patterns alone.
+- Cleanup fails closed on unrecognized ownership records: unknown roles/engines, invalid names, or mixed engines abort database cleanup with zero SQL executed.
+- Cleanup, listing, and client errors are aggregated deterministically (`errors.Join`), including row-iteration and close errors.
+- The "Update Changelog" workflow skips releases whose CHANGELOG section is already curated (deterministic single-writer guard).
+
+### Fixed
+
+- PostgreSQL re-scaffold no longer rotates the database suffix or accumulates ownership records; persisted-suffix collisions are treated as idempotent success.
+- `_` in cleanup `LIKE` patterns no longer acts as a wildcard — patterns are escaped and returned names revalidated before any drop.
+- Database listings use parameterized queries instead of string-interpolated SQL.
+- Laravel scaffold conditionally clears the PHPStan/Larastan result cache after `.env` updates when `vendor/bin/phpstan` exists.
+
 ## [v1.7.1](https://github.com/naoray/anvil/compare/v1.7.0...v1.7.1) - 2026-04-30
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,7 +13,7 @@ See [AGENTS.md](./AGENTS.md) for full architecture, workflows, and conventions.
 
 ## Release
 
-Update CHANGELOG.md, commit, tag with `vX.Y.Z`, push, and create a GitHub release via `gh release create`.
+Update CHANGELOG.md, commit, tag with an annotated `vX.Y.Z` tag, and push — the tag push triggers release.yml, which builds binaries and creates the GitHub release automatically.
 
 ## Framework-Specific Rules
 

--- a/README.md
+++ b/README.md
@@ -378,6 +378,132 @@ anvil completion fish > ~/.config/fish/completions/anvil.fish
 anvil completion powershell > anvil.ps1
 ```
 
+## Test Database Isolation
+
+Parallel worktrees used to share one test database: Laravel's `phpunit.xml`
+commonly pins `DB_DATABASE`, and phpunit.xml values beat `.env`, so test runs
+from two worktrees wiped each other's data. Anvil scaffolds a dedicated test
+database per worktree and provides `anvil exec` to run commands with it
+exported.
+
+### How it works
+
+Scaffolding a worktree (Laravel preset) creates two databases and records
+them in `.anvil.local` (generated, git-ignored, no credentials; unknown
+fields are preserved on rewrite):
+
+```yaml
+db_suffix: swift_runner
+databases:
+  - name: myapp_swift_runner
+    engine: mysql
+    role: application
+  - name: myapp_swift_runner_test
+    engine: mysql
+    role: testing
+```
+
+- `role: application` (the default) is the regular app database step; its
+  create persists an ownership record.
+- `role: testing` derives `<site>_<suffix>_test` (capped at 54 characters so
+  Laravel's parallel-worker suffixes still fit MySQL's 64 and PostgreSQL's 63
+  identifier limits), creates it empty — no migrations; your test runner
+  handles schema per run — and re-scaffolds idempotently.
+- Custom scaffold steps can reference the name via `{{ .TestDatabaseName }}`.
+
+### `anvil exec`
+
+Runs a command with the worktree's test database exported. Strictly
+read-only: it never creates or modifies databases or `.anvil.local`.
+
+```bash
+# Run the test suite against the worktree's test database
+anvil exec -- ./scripts/git/run-tests.sh --parallel
+
+# Works without -- too; child flags pass through
+anvil exec php artisan test
+
+# Inspect what the child sees
+anvil exec -- php -r 'echo getenv("DB_DATABASE");'
+```
+
+Environment exported to the child (inherited values are replaced,
+case-insensitively on Windows):
+
+```
+DB_DATABASE=<test database>                # e.g. myapp_swift_runner_test
+ANVIL_TEST_DB_DATABASE=<test database>
+ANVIL_DB_DATABASE=<application database>   # omitted if unknown
+```
+
+Exit codes: the child's exit code is passed through (on Unix via `execve`,
+on Windows via typed propagation). `127` means the command was not found,
+`126` means it was found but could not be executed, and `1` is anvil's own
+resolution failure. Windows note: anvil remains the parent process; Ctrl+C
+reaches the child via the shared console, but there is no Unix-style signal
+forwarding or job-object management.
+
+### Pre-push and CI recipes
+
+Anvil never installs or owns git hooks and never patches tracked
+`phpunit.xml`. Wrap the outer script instead:
+
+```bash
+# Run the whole pre-push script with the test database exported
+anvil exec -- ./scripts/git/pre-push.sh
+```
+
+Local, untracked pre-push shim (`.git/hooks/pre-push`):
+
+```sh
+#!/bin/sh
+exec anvil exec -- ./scripts/git/pre-push.sh "$@"
+```
+
+`exec` replaces the shim process, so git's ref-list stdin reaches the script
+unchanged.
+
+### Cleaning up
+
+`anvil remove` drops the exact owned databases recorded in `.anvil.local`
+plus Laravel parallel-worker databases for both families
+(`<app>_test_<n>` and `<test>_test_<n>`):
+
+```bash
+# Preview the exact drop set (live enumeration, zero mutation)
+anvil remove feature-x --dry-run
+
+# Remove the worktree but keep every database
+anvil remove feature-x --keep-db
+```
+
+`--dry-run` prints one `Would drop database: <name>` line per database and
+never drops databases or removes the worktree. `--keep-db` prints the
+preserved names (parallel-worker databases are kept too; drop them manually
+when done). If `.anvil.local` is unreadable or contains records anvil does
+not understand, `remove` stops before deleting the worktree unless `--force`
+is given — databases are then left untouched and unrecorded.
+
+### Limitations (v1.8)
+
+- `force="true"` or `<server>` entries in `phpunit.xml` beat the exported
+  environment and are not detected (a config scanner is deferred).
+- A cached Laravel config (`bootstrap/cache/config.php`) beats the
+  environment and is not detected.
+- Bare invocations that bypass `anvil exec` keep today's shared behavior.
+- `env -i`, containers without environment forwarding, and `DB_URL`-only
+  connections are out of scope.
+- Laravel caches parallel-worker databases between runs; run
+  `php artisan test --recreate-databases` after schema-heavy branch
+  switches.
+- Pre-1.8 worktrees have no recorded testing database: create a new
+  worktree, or configure a scaffold override containing ONLY a `db.create`
+  step with `role: testing` and run that. `anvil exec` never creates or
+  modifies databases or `.anvil.local`.
+- One database server connection per worktree (MySQL or PostgreSQL).
+  SQLite worktrees are per-worktree files and already isolated, so
+  `anvil exec` is not needed there.
+
 ## Configuration
 
 Anvil uses a three-tier configuration system to separate team configuration from local state.
@@ -613,6 +739,7 @@ All steps support template variables that are replaced at runtime:
 | `{{ .Branch }}` | Git branch name | `feature-auth` |
 | `{{ .DbSuffix }}` | Database suffix (from db.create) | `swift_runner` |
 | `{{ .DatabaseName }}` | Full database name (truncated to 63 chars) | `myapp_swift_runner` |
+| `{{ .TestDatabaseName }}` | Test database name (capped at 54 chars) | `myapp_swift_runner_test` |
 | `{{ .VarName }}` | Custom variable from env.read or captured output | Custom values |
 
 ### Built-in Steps

--- a/README.md
+++ b/README.md
@@ -966,6 +966,7 @@ This creates: `app_cool_engine`, `quotes_cool_engine`, `knowledge_cool_engine`
 - Preserves file permissions
 - Maintains existing formatting (comments, blank lines, ordering)
 - Creates directories as needed
+- The Laravel preset clears PHPStan/Larastan's result cache after creating or updating `.env` when `vendor/bin/phpstan` is available; projects without PHPStan are skipped
 
 **Error Handling**
 - Graceful degradation where appropriate

--- a/anvil-agent/SKILL.md
+++ b/anvil-agent/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: anvil-agent
-description: Use when working in repositories managed by Anvil, a git worktree manager for agentic development. Covers Anvil commands, worktree workflow, config files, and development conventions for AI coding agents including Codex and Claude Code.
+description: Use when working in repositories managed by Anvil, a git worktree manager for agentic development. Covers worktree commands and workflow, scaffold configuration, isolated application and test databases, read-only command execution with anvil exec, safe cleanup, and development conventions for AI coding agents including Codex and Claude Code.
 ---
 
 # Anvil Agent
@@ -15,8 +15,11 @@ anvil work <branch>        # Create or checkout a worktree
 anvil list                 # List linked worktrees
 anvil info <branch>        # Print the path to a worktree
 anvil scaffold <branch>    # Run scaffold steps for a worktree
+anvil exec -- <command>    # Run with the worktree test database exported
 anvil sync                 # Sync current worktree with upstream
 anvil remove <branch>      # Remove a worktree
+anvil remove <branch> --dry-run  # Preview database and worktree cleanup
+anvil remove <branch> --keep-db  # Remove the worktree but retain databases
 anvil prune                # Remove merged worktrees
 ```
 
@@ -25,14 +28,43 @@ anvil prune                # Remove merged worktrees
 1. Create isolated feature work with `anvil work feature/name`.
 2. Move into the worktree path from the command output or `anvil info feature-name`.
 3. Implement and test inside the worktree.
-4. Wait for user review before committing.
-5. Clean up with `anvil remove feature-name` or `anvil prune` after the work is landed.
+4. In Laravel worktrees, run test and pre-push commands through `anvil exec -- <command>` so they use the worktree's isolated test database.
+5. Wait for user review before committing.
+6. Preview cleanup with `anvil remove feature-name --dry-run`, then clean up with `anvil remove feature-name` or `anvil prune` after the work is landed.
 
 ## Config Files
 
 - Repository config: `anvil.yaml`
-- Local worktree state: `.anvil.local` (should be gitignored)
+- Local worktree state: `.anvil.local` (generated and gitignored; contains `db_suffix` and owned database records)
 - Global config: `~/.config/anvil/anvil.yaml`
+
+Do not rewrite `.anvil.local` casually. Anvil preserves unknown fields and uses its ownership records to decide which databases cleanup may drop.
+
+## Test Database Isolation
+
+The Laravel preset creates and records an application database plus an empty testing database:
+
+```yaml
+databases:
+  - name: myapp_swift_runner
+    engine: mysql
+    role: application
+  - name: myapp_swift_runner_test
+    engine: mysql
+    role: testing
+```
+
+Use `anvil exec` for local test commands instead of invoking them bare. It is read-only: it resolves the recorded databases, exports `DB_DATABASE` and `ANVIL_TEST_DB_DATABASE` for the testing database plus `ANVIL_DB_DATABASE` when the application database is known, then runs the child without modifying databases or `.anvil.local`.
+
+- Child exit codes pass through. Exit `127` means missing; `126` means found but not executable; `1` is an Anvil resolution error.
+- `anvil remove <worktree> --dry-run` performs live enumeration but no mutation and prints the exact owned application, testing, and parallel-worker databases it would drop.
+- `anvil remove <worktree> --keep-db` removes the worktree while preserving every database.
+- Unreadable or invalid ownership state stops removal before the worktree is deleted unless the user explicitly supplies `--force`; forced removal leaves databases untouched.
+- Pre-v1.8 worktrees may lack a testing record. Do not assume one or let `anvil exec` create it; scaffold a testing-role `db.create` step or create a fresh worktree.
+
+## Laravel Scaffold Cache
+
+After the Laravel preset creates or updates `.env`, it clears the PHPStan/Larastan result cache when `vendor/bin/phpstan` exists. Projects without that binary are skipped. Account for this command when diagnosing scaffold failures or writing preset tests.
 
 ## Development Rules
 

--- a/anvil-agent/skill_test.go
+++ b/anvil-agent/skill_test.go
@@ -12,4 +12,16 @@ func TestSkillContentIsEmbedded(t *testing.T) {
 	if !bytes.Contains(Content, []byte("Codex")) {
 		t.Fatal("expected embedded skill content to mention Codex")
 	}
+
+	requiredGuidance := [][]byte{
+		[]byte("anvil exec"),
+		[]byte("databases:"),
+		[]byte("--keep-db"),
+		[]byte("PHPStan/Larastan"),
+	}
+	for _, fragment := range requiredGuidance {
+		if !bytes.Contains(Content, fragment) {
+			t.Fatalf("expected embedded skill content to include %q", fragment)
+		}
+	}
 }

--- a/cmd/anvil/main.go
+++ b/cmd/anvil/main.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"errors"
+	"fmt"
 	"os"
 
 	"github.com/naoray/anvil/internal/cli"
@@ -18,6 +20,13 @@ func main() {
 	cli.Commit = Commit
 	cli.BuildDate = BuildDate
 	if err := cli.Execute(); err != nil {
+		var childErr *cli.ChildExitError
+		if errors.As(err, &childErr) {
+			if childErr.Message != "" {
+				fmt.Fprintln(os.Stderr, childErr.Message)
+			}
+			os.Exit(childErr.Code)
+		}
 		os.Exit(1)
 	}
 }

--- a/internal/cli/context.go
+++ b/internal/cli/context.go
@@ -83,6 +83,7 @@ func openProject(cwd, projectName string, projectInfo *config.ProjectInfo, globa
 		Preset:        projectInfo.Preset,
 		DefaultBranch: defaultBranch,
 		EditorCmd:     projectInfo.EditorCmd,
+		Cleanup:       projectInfo.Cleanup,
 	}
 
 	return &ProjectContext{

--- a/internal/cli/exec.go
+++ b/internal/cli/exec.go
@@ -1,0 +1,202 @@
+package cli
+
+import (
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/naoray/anvil/internal/config"
+	"github.com/naoray/anvil/internal/ui"
+	"github.com/naoray/anvil/internal/utils"
+)
+
+// legacyExecHint is the locked fail-safe contract text for worktrees without a
+// recorded testing database. exec never creates databases or touches
+// .anvil.local, so the message spells out the safe remediation paths.
+const legacyExecHint = `no testing database is recorded in .anvil.local — 'anvil exec' is available for
+worktrees scaffolded with Anvil v1.8 or later.
+Options:
+  - create a new worktree ('anvil work <branch>') to get an isolated test database, or
+  - configure a scaffold override containing ONLY a 'db.create' step with 'role: testing'
+    and run that in this worktree.
+anvil exec never creates or modifies databases or .anvil.local.
+Do NOT rerun the full default Laravel scaffold here if this worktree's database
+holds data you care about — it runs 'migrate:fresh' and would wipe it.`
+
+const sharedDbExecHint = `this worktree appears to use a shared database; shared-database worktrees do not support 'anvil exec'.`
+
+const sqliteExecHint = `SQLite databases are per-worktree files; the worktree is already isolated and 'anvil exec' is not needed.`
+
+// These are the environment variables anvil exec owns: inherited values are
+// dropped and replaced with the worktree's recorded databases.
+const (
+	execDatabaseEnvKey     = "DB_DATABASE"
+	execAppDatabaseEnvKey  = "ANVIL_DB_DATABASE"
+	execTestDatabaseEnvKey = "ANVIL_TEST_DB_DATABASE"
+)
+
+var execCmd = &cobra.Command{
+	Use:   "exec [--] COMMAND [ARGS...]",
+	Short: "Run a command with the worktree's test database exported",
+	Long: `Run a command with the worktree's isolated test database exported.
+
+Exports DB_DATABASE and ANVIL_TEST_DB_DATABASE set to the worktree's testing
+database (and ANVIL_DB_DATABASE set to the application database when known),
+then executes COMMAND. The child's exit code is passed through.
+
+anvil exec is strictly read-only: it never creates or modifies databases or
+.anvil.local.`,
+	Args: func(cmd *cobra.Command, args []string) error {
+		err := cobra.MinimumNArgs(1)(cmd, args)
+		if err != nil {
+			ui.PrintError(err.Error())
+		}
+		return err
+	},
+	SilenceUsage:  true,
+	SilenceErrors: true,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		cwd, err := os.Getwd()
+		if err != nil {
+			ui.PrintError(err.Error())
+			return err
+		}
+		root, err := findWorktreeRoot(cwd)
+		if err != nil {
+			ui.PrintError(err.Error())
+			return err
+		}
+		appDb, testDb, err := resolveExecDatabases(root)
+		if err != nil {
+			ui.PrintError(err.Error())
+			return err
+		}
+		env := buildExecEnv(os.Environ(), appDb, testDb, runtime.GOOS == "windows")
+		return runChild(args, env)
+	},
+}
+
+func init() {
+	// Child flags pass through without "--": anvil exec ./script.sh --parallel.
+	execCmd.Flags().SetInterspersed(false)
+	execCmd.SetFlagErrorFunc(func(_ *cobra.Command, err error) error {
+		ui.PrintError(err.Error())
+		return err
+	})
+	rootCmd.AddCommand(execCmd)
+}
+
+// findWorktreeRoot walks up from start to the first directory containing
+// .anvil.local. Stat errors other than not-exist are surfaced, never treated
+// as not-found.
+func findWorktreeRoot(start string) (string, error) {
+	dir := start
+	for {
+		statePath := filepath.Join(dir, config.LocalStateFile)
+		info, err := os.Stat(statePath)
+		if err == nil {
+			if !info.IsDir() {
+				return dir, nil
+			}
+		} else if !errors.Is(err, fs.ErrNotExist) {
+			return "", fmt.Errorf("checking %s: %w", statePath, err)
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			return "", fmt.Errorf("no .anvil.local found in %s or any parent directory (run 'anvil scaffold' in the worktree first)", start)
+		}
+		dir = parent
+	}
+}
+
+// resolveExecDatabases reads the worktree's owned-database records and returns
+// the application (may be empty) and testing database names. It is strictly
+// read-only; the diagnostic .env read only refines error messages.
+func resolveExecDatabases(worktreeRoot string) (string, string, error) {
+	state, err := config.ReadLocalState(worktreeRoot)
+	if err != nil {
+		return "", "", fmt.Errorf("reading %s: %w", config.LocalStateFile, err)
+	}
+	envValues := utils.ReadEnvFile(worktreeRoot, ".env")
+
+	// SQLite worktrees are already isolated; this precise refusal takes
+	// precedence over the generic record validator.
+	sqliteRecorded := false
+	for _, database := range state.Databases {
+		if strings.EqualFold(database.Engine, "sqlite") {
+			sqliteRecorded = true
+			break
+		}
+	}
+	if sqliteRecorded || strings.EqualFold(envValues["DB_CONNECTION"], "sqlite") {
+		return "", "", errors.New(sqliteExecHint) //nolint:staticcheck // ST1005: locked user-facing CLI contract wording
+	}
+
+	if err := config.ValidateOwnedDatabases(state.Databases); err != nil {
+		return "", "", err
+	}
+
+	var appNames, testNames []string
+	for _, database := range state.Databases {
+		switch database.Role {
+		case config.DbRoleApplication:
+			appNames = append(appNames, database.Name)
+		case config.DbRoleTesting:
+			testNames = append(testNames, database.Name)
+		}
+	}
+
+	if len(testNames) > 1 {
+		return "", "", fmt.Errorf("multiple testing databases recorded in .anvil.local (%s); remove the stale entries and retry.", strings.Join(testNames, ", ")) //nolint:staticcheck // ST1005: locked user-facing CLI contract wording
+	}
+	if len(appNames) > 1 {
+		return "", "", fmt.Errorf("multiple application databases recorded in .anvil.local (%s); remove the stale entries and retry.", strings.Join(appNames, ", ")) //nolint:staticcheck // ST1005: locked user-facing CLI contract wording
+	}
+	if len(testNames) == 0 {
+		message := legacyExecHint
+		if dbName := envValues["DB_DATABASE"]; dbName != "" && state.DbSuffix != "" && !strings.HasSuffix(dbName, "_"+state.DbSuffix) {
+			message += "\n" + sharedDbExecHint
+		}
+		return "", "", errors.New(message) //nolint:staticcheck // ST1005: locked user-facing CLI contract wording
+	}
+
+	appDb := ""
+	if len(appNames) == 1 {
+		appDb = appNames[0]
+	}
+	return appDb, testNames[0], nil
+}
+
+// buildExecEnv returns environ with the managed database variables replaced by
+// the worktree's values. caseInsensitiveKeys matches Windows environment
+// semantics, where DB_DATABASE and db_database are the same variable.
+func buildExecEnv(environ []string, appDb, testDb string, caseInsensitiveKeys bool) []string {
+	out := make([]string, 0, len(environ)+3)
+	for _, entry := range environ {
+		key, _, found := strings.Cut(entry, "=")
+		if found && isManagedExecEnvKey(key, caseInsensitiveKeys) {
+			continue
+		}
+		out = append(out, entry)
+	}
+	out = append(out, execDatabaseEnvKey+"="+testDb, execTestDatabaseEnvKey+"="+testDb)
+	if appDb != "" {
+		out = append(out, execAppDatabaseEnvKey+"="+appDb)
+	}
+	return out
+}
+
+func isManagedExecEnvKey(key string, caseInsensitive bool) bool {
+	return key == execDatabaseEnvKey ||
+		key == execAppDatabaseEnvKey ||
+		key == execTestDatabaseEnvKey ||
+		(caseInsensitive && (strings.EqualFold(key, execDatabaseEnvKey) ||
+			strings.EqualFold(key, execAppDatabaseEnvKey) ||
+			strings.EqualFold(key, execTestDatabaseEnvKey)))
+}

--- a/internal/cli/exec_integration_test.go
+++ b/internal/cli/exec_integration_test.go
@@ -1,0 +1,313 @@
+package cli
+
+import (
+	"bytes"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/naoray/anvil/internal/config"
+)
+
+// subprocessEnv returns os.Environ with HOME and XDG_CONFIG_HOME isolated to a
+// fresh temp dir and the given KEY=VALUE overrides applied, replacing any
+// inherited entry with the same key so the slice never carries duplicates.
+func subprocessEnv(t *testing.T, overrides ...string) []string {
+	t.Helper()
+	fakeHome := t.TempDir()
+	base := append(os.Environ(),
+		"HOME="+fakeHome,
+		"XDG_CONFIG_HOME="+filepath.Join(fakeHome, "config"),
+	)
+	base = append(base, overrides...)
+
+	seen := make(map[string]int)
+	out := make([]string, 0, len(base))
+	for _, entry := range base {
+		key, _, ok := strings.Cut(entry, "=")
+		if !ok {
+			out = append(out, entry)
+			continue
+		}
+		if index, exists := seen[key]; exists {
+			out[index] = entry
+			continue
+		}
+		seen[key] = len(out)
+		out = append(out, entry)
+	}
+	return out
+}
+
+// helperSelf returns the running test binary, re-invoked as the exec child via
+// the ANVIL_TEST_HELPER/ANVIL_HELPER_MODE dispatch in TestMain.
+func helperSelf(t *testing.T) string {
+	t.Helper()
+	self, err := os.Executable()
+	require.NoError(t, err)
+	return self
+}
+
+func writeExecIntegrationState(t *testing.T, dir string) (appDb, testDb string) {
+	t.Helper()
+	appDb = "demo_brave_otter"
+	testDb = "demo_brave_otter_test"
+	require.NoError(t, config.WriteLocalState(dir, config.LocalState{
+		DbSuffix: "brave_otter",
+		Databases: []config.OwnedDatabase{
+			{Name: appDb, Engine: "mysql", Role: config.DbRoleApplication},
+			{Name: testDb, Engine: "mysql", Role: config.DbRoleTesting},
+		},
+	}))
+	return appDb, testDb
+}
+
+func TestExecCommand_ExportsTestDatabase(t *testing.T) {
+	bin := getAnvilBinary(t)
+	dir := t.TempDir()
+	appDb, testDb := writeExecIntegrationState(t, dir)
+
+	cmd := exec.Command(bin, "exec", "--", helperSelf(t))
+	cmd.Dir = dir
+	cmd.Env = subprocessEnv(t,
+		"DB_DATABASE=should_be_replaced",
+		"ANVIL_TEST_HELPER=1",
+		"ANVIL_HELPER_MODE=env",
+	)
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	require.NoError(t, cmd.Run(), "stdout: %s\nstderr: %s", stdout.String(), stderr.String())
+	out := stdout.String()
+	assert.Contains(t, out, "DB_DATABASE="+testDb+"\n")
+	assert.Contains(t, out, "ANVIL_TEST_DB_DATABASE="+testDb+"\n")
+	assert.Contains(t, out, "ANVIL_DB_DATABASE="+appDb+"\n")
+	assert.NotContains(t, out, "should_be_replaced")
+}
+
+func TestExecCommand_ArgvFidelity(t *testing.T) {
+	bin := getAnvilBinary(t)
+	dir := t.TempDir()
+	writeExecIntegrationState(t, dir)
+
+	cmd := exec.Command(bin, "exec", "--", helperSelf(t), "hello world", "--flag", "-x", "trailing space ")
+	cmd.Dir = dir
+	cmd.Env = subprocessEnv(t,
+		"ANVIL_TEST_HELPER=1",
+		"ANVIL_HELPER_MODE=env",
+	)
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	require.NoError(t, cmd.Run(), "stdout: %s\nstderr: %s", stdout.String(), stderr.String())
+	out := stdout.String()
+	assert.Contains(t, out, "argv[0]=hello world\n")
+	assert.Contains(t, out, "argv[1]=--flag\n")
+	assert.Contains(t, out, "argv[2]=-x\n")
+	assert.Contains(t, out, "argv[3]=trailing space \n")
+}
+
+func TestExecCommand_PropagatesExitCode(t *testing.T) {
+	bin := getAnvilBinary(t)
+	dir := t.TempDir()
+	writeExecIntegrationState(t, dir)
+
+	cmd := exec.Command(bin, "exec", "--", helperSelf(t))
+	cmd.Dir = dir
+	cmd.Env = subprocessEnv(t,
+		"ANVIL_TEST_HELPER=1",
+		"ANVIL_HELPER_MODE=exit",
+		"ANVIL_HELPER_EXIT=7",
+	)
+
+	err := cmd.Run()
+	var exitErr *exec.ExitError
+	require.ErrorAs(t, err, &exitErr)
+	assert.Equal(t, 7, exitErr.ExitCode())
+}
+
+func TestExecCommand_StdinStdoutFidelity(t *testing.T) {
+	bin := getAnvilBinary(t)
+	dir := t.TempDir()
+	writeExecIntegrationState(t, dir)
+	payload := []byte("ref deadbeef refs/heads/main\nline2 with spaces\nfinal line no newline")
+
+	cmd := exec.Command(bin, "exec", "--", helperSelf(t))
+	cmd.Dir = dir
+	cmd.Env = subprocessEnv(t,
+		"ANVIL_TEST_HELPER=1",
+		"ANVIL_HELPER_MODE=cat",
+	)
+	cmd.Stdin = bytes.NewReader(payload)
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	require.NoError(t, cmd.Run(), "stderr: %s", stderr.String())
+	assert.Equal(t, payload, stdout.Bytes(), "stdin must reach the child and stdout must return verbatim")
+}
+
+func TestExecCommand_StderrFidelity(t *testing.T) {
+	bin := getAnvilBinary(t)
+	dir := t.TempDir()
+	writeExecIntegrationState(t, dir)
+	message := "worker 3 failed: deadlock detected\nsecond stderr line"
+
+	cmd := exec.Command(bin, "exec", "--", helperSelf(t))
+	cmd.Dir = dir
+	cmd.Env = subprocessEnv(t,
+		"ANVIL_TEST_HELPER=1",
+		"ANVIL_HELPER_MODE=stderr",
+		"ANVIL_HELPER_STDERR="+message,
+	)
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	require.NoError(t, cmd.Run(), "stderr: %s", stderr.String())
+	assert.Equal(t, message, stderr.String(), "child stderr bytes must arrive on the outer stderr exactly")
+	assert.Empty(t, stdout.String(), "stderr output must not leak onto stdout")
+}
+
+func TestExecCommand_CommandNotFound127(t *testing.T) {
+	bin := getAnvilBinary(t)
+	dir := t.TempDir()
+	writeExecIntegrationState(t, dir)
+
+	cmd := exec.Command(bin, "exec", "--", "definitely-not-a-real-command-anvil-2273")
+	cmd.Dir = dir
+	cmd.Env = subprocessEnv(t)
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	err := cmd.Run()
+	var exitErr *exec.ExitError
+	require.ErrorAs(t, err, &exitErr)
+	assert.Equal(t, 127, exitErr.ExitCode())
+	assert.Contains(t, stderr.String(), "command not found: definitely-not-a-real-command-anvil-2273")
+}
+
+func TestExecCommand_NoCommandPrintsValidationErrorOnce(t *testing.T) {
+	bin := getAnvilBinary(t)
+	cmd := exec.Command(bin, "exec")
+	cmd.Env = subprocessEnv(t)
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	err := cmd.Run()
+	var exitErr *exec.ExitError
+	require.ErrorAs(t, err, &exitErr)
+	assert.Equal(t, 1, exitErr.ExitCode())
+	assert.Empty(t, stdout.String())
+	const validation = "requires at least 1 arg(s), only received 0"
+	assert.Equal(t, 1, strings.Count(stderr.String(), validation), stderr.String())
+	assert.NotContains(t, stderr.String(), "Usage:")
+	assert.NotContains(t, stderr.String(), "Error:")
+}
+
+func TestExecCommand_UnknownAnvilFlagPrintsValidationErrorOnce(t *testing.T) {
+	bin := getAnvilBinary(t)
+	cmd := exec.Command(bin, "exec", "--anvil-invalid")
+	cmd.Env = subprocessEnv(t)
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	err := cmd.Run()
+	var exitErr *exec.ExitError
+	require.ErrorAs(t, err, &exitErr)
+	assert.Equal(t, 1, exitErr.ExitCode())
+	assert.Empty(t, stdout.String())
+	const validation = "unknown flag: --anvil-invalid"
+	assert.Equal(t, 1, strings.Count(stderr.String(), validation), stderr.String())
+	assert.NotContains(t, stderr.String(), "Usage:")
+	assert.NotContains(t, stderr.String(), "Error:")
+}
+
+func TestExecCommand_ErrorsOutsideScaffoldedWorktree(t *testing.T) {
+	bin := getAnvilBinary(t)
+	dir := t.TempDir()
+
+	cmd := exec.Command(bin, "exec", "--", helperSelf(t))
+	cmd.Dir = dir
+	cmd.Env = subprocessEnv(t,
+		"ANVIL_TEST_HELPER=1",
+		"ANVIL_HELPER_MODE=env",
+	)
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	err := cmd.Run()
+	var exitErr *exec.ExitError
+	require.ErrorAs(t, err, &exitErr)
+	assert.Equal(t, 1, exitErr.ExitCode())
+	assert.Contains(t, stderr.String(), "no .anvil.local found")
+	assert.Contains(t, stderr.String(), "anvil scaffold")
+}
+
+func TestExecCommand_LegacyWorktreeFailSafe(t *testing.T) {
+	bin := getAnvilBinary(t)
+	dir := t.TempDir()
+	require.NoError(t, config.WriteLocalState(dir, config.LocalState{DbSuffix: "top_provider"}))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, ".env"),
+		[]byte("DB_CONNECTION=mysql\nDB_DATABASE=demo_top_provider\n"), 0o644))
+	before, err := os.ReadFile(filepath.Join(dir, config.LocalStateFile))
+	require.NoError(t, err)
+
+	cmd := exec.Command(bin, "exec", "--", helperSelf(t))
+	cmd.Dir = dir
+	cmd.Env = subprocessEnv(t,
+		"ANVIL_TEST_HELPER=1",
+		"ANVIL_HELPER_MODE=env",
+	)
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	runErr := cmd.Run()
+	var exitErr *exec.ExitError
+	require.ErrorAs(t, runErr, &exitErr)
+	assert.Equal(t, 1, exitErr.ExitCode())
+	assert.Contains(t, stderr.String(), "v1.8")
+	assert.Contains(t, stderr.String(), "migrate:fresh")
+
+	after, err := os.ReadFile(filepath.Join(dir, config.LocalStateFile))
+	require.NoError(t, err)
+	assert.Equal(t, before, after, "anvil exec must never modify .anvil.local")
+}
+
+func TestExecCommand_NoFirstRunWizard(t *testing.T) {
+	bin := getAnvilBinary(t)
+	dir := t.TempDir()
+	_, testDb := writeExecIntegrationState(t, dir)
+
+	configHome := t.TempDir()
+	cmd := exec.Command(bin, "exec", "--", helperSelf(t))
+	cmd.Dir = dir
+	cmd.Env = subprocessEnv(t,
+		"XDG_CONFIG_HOME="+configHome,
+		"ANVIL_TEST_HELPER=1",
+		"ANVIL_HELPER_MODE=env",
+	)
+	cmd.Stdin = nil // closed stdin: a wizard prompt would fail, not hang
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	require.NoError(t, cmd.Run(), "stdout: %s\nstderr: %s", stdout.String(), stderr.String())
+	assert.Contains(t, stdout.String(), "DB_DATABASE="+testDb+"\n")
+
+	entries, err := os.ReadDir(configHome)
+	require.NoError(t, err)
+	assert.Empty(t, entries, "exec must not create global config state")
+}

--- a/internal/cli/exec_lookup.go
+++ b/internal/cli/exec_lookup.go
@@ -1,0 +1,44 @@
+package cli
+
+import (
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+func childLookPathError(command string, lookupErr error) error {
+	if lookupFailureMeansCannotExecute(command, lookupErr) {
+		return &ChildExitError{
+			Code:    126,
+			Message: fmt.Sprintf("cannot execute %s: %v", command, lookupErr),
+		}
+	}
+	return &ChildExitError{Code: 127, Message: fmt.Sprintf("command not found: %s", command)}
+}
+
+func lookupFailureMeansCannotExecute(command string, lookupErr error) bool {
+	if errors.Is(lookupErr, fs.ErrPermission) {
+		return true
+	}
+
+	if filepath.IsAbs(command) || strings.ContainsAny(command, `/\`) {
+		return pathExistsOrIsBlocked(command)
+	}
+	for _, dir := range filepath.SplitList(os.Getenv("PATH")) {
+		if pathExistsOrIsBlocked(filepath.Join(dir, command)) {
+			return true
+		}
+	}
+	return false
+}
+
+func pathExistsOrIsBlocked(path string) bool {
+	if _, err := os.Stat(path); err == nil || !errors.Is(err, fs.ErrNotExist) {
+		return true
+	}
+	_, err := os.Lstat(path)
+	return err == nil || !errors.Is(err, fs.ErrNotExist)
+}

--- a/internal/cli/exec_test.go
+++ b/internal/cli/exec_test.go
@@ -1,0 +1,292 @@
+package cli
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/naoray/anvil/internal/config"
+)
+
+// writeExecStateFile writes a raw .anvil.local so tests can construct states
+// (e.g. duplicate roles) that config.WriteLocalState's canonical merge would
+// never produce.
+func writeExecStateFile(t *testing.T, dir, content string) {
+	t.Helper()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, config.LocalStateFile), []byte(content), 0o644))
+}
+
+func countEnvKey(env []string, key string) int {
+	count := 0
+	for _, entry := range env {
+		if strings.HasPrefix(entry, key+"=") {
+			count++
+		}
+	}
+	return count
+}
+
+func TestBuildExecEnv_ReplacesInheritedValues(t *testing.T) {
+	env := buildExecEnv([]string{
+		"DB_DATABASE=inherited_db",
+		"ANVIL_DB_DATABASE=inherited_app",
+		"ANVIL_TEST_DB_DATABASE=inherited_test",
+		"PATH=/usr/bin",
+	}, "demo_app", "demo_app_test", false)
+
+	assert.Contains(t, env, "DB_DATABASE=demo_app_test")
+	assert.Contains(t, env, "ANVIL_TEST_DB_DATABASE=demo_app_test")
+	assert.Contains(t, env, "ANVIL_DB_DATABASE=demo_app")
+	assert.Contains(t, env, "PATH=/usr/bin")
+	assert.Equal(t, 1, countEnvKey(env, "DB_DATABASE"))
+	assert.Equal(t, 1, countEnvKey(env, "ANVIL_TEST_DB_DATABASE"))
+	assert.Equal(t, 1, countEnvKey(env, "ANVIL_DB_DATABASE"))
+	assert.NotContains(t, env, "DB_DATABASE=inherited_db")
+	assert.NotContains(t, env, "ANVIL_DB_DATABASE=inherited_app")
+	assert.NotContains(t, env, "ANVIL_TEST_DB_DATABASE=inherited_test")
+}
+
+func TestBuildExecEnv_OmitsUnknownApplicationDatabase(t *testing.T) {
+	env := buildExecEnv([]string{"ANVIL_DB_DATABASE=stale"}, "", "demo_test", false)
+
+	assert.Contains(t, env, "DB_DATABASE=demo_test")
+	assert.Contains(t, env, "ANVIL_TEST_DB_DATABASE=demo_test")
+	assert.Equal(t, 0, countEnvKey(env, "ANVIL_DB_DATABASE"))
+}
+
+func TestBuildExecEnv_WindowsCaseInsensitiveKeys(t *testing.T) {
+	out := buildExecEnv([]string{"db_database=stale", "Db_DaTaBaSe=stale2", "PATH=/bin"}, "app", "test", true)
+
+	for _, entry := range out {
+		key, _, found := strings.Cut(entry, "=")
+		require.True(t, found, "malformed env entry %q", entry)
+		if strings.EqualFold(key, "DB_DATABASE") {
+			assert.Equal(t, "DB_DATABASE=test", entry, "case-variant DB_DATABASE survived: %q", entry)
+		}
+	}
+	assert.Contains(t, out, "DB_DATABASE=test")
+	assert.Contains(t, out, "PATH=/bin")
+	assert.NotContains(t, out, "db_database=stale")
+	assert.NotContains(t, out, "Db_DaTaBaSe=stale2")
+}
+
+func TestFindWorktreeRoot(t *testing.T) {
+	root := t.TempDir()
+	writeExecStateFile(t, root, "db_suffix: top_provider\n")
+	nested := filepath.Join(root, "app", "Http")
+	require.NoError(t, os.MkdirAll(nested, 0o755))
+
+	found, err := findWorktreeRoot(nested)
+	require.NoError(t, err)
+	assert.Equal(t, root, found)
+
+	empty := t.TempDir()
+	_, err = findWorktreeRoot(empty)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no .anvil.local found")
+	assert.Contains(t, err.Error(), "anvil scaffold")
+	assert.Contains(t, err.Error(), empty)
+}
+
+func TestResolveExecDatabases_FromOwnedState(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, config.WriteLocalState(dir, config.LocalState{
+		DbSuffix: "top_provider",
+		Databases: []config.OwnedDatabase{
+			{Name: "demo_top_provider", Engine: "mysql", Role: config.DbRoleApplication},
+			{Name: "demo_top_provider_test", Engine: "mysql", Role: config.DbRoleTesting},
+		},
+	}))
+
+	appDb, testDb, err := resolveExecDatabases(dir)
+	require.NoError(t, err)
+	assert.Equal(t, "demo_top_provider", appDb)
+	assert.Equal(t, "demo_top_provider_test", testDb)
+}
+
+func TestResolveExecDatabases_TestingOnlyStateOmitsAppDb(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, config.WriteLocalState(dir, config.LocalState{
+		DbSuffix: "top_provider",
+		Databases: []config.OwnedDatabase{
+			{Name: "demo_top_provider_test", Engine: "pgsql", Role: config.DbRoleTesting},
+		},
+	}))
+
+	appDb, testDb, err := resolveExecDatabases(dir)
+	require.NoError(t, err)
+	assert.Empty(t, appDb)
+	assert.Equal(t, "demo_top_provider_test", testDb)
+}
+
+func TestResolveExecDatabases_MultipleTestingEntriesError(t *testing.T) {
+	dir := t.TempDir()
+	writeExecStateFile(t, dir, `db_suffix: top_provider
+databases:
+  - name: demo_a_test
+    engine: mysql
+    role: testing
+  - name: demo_b_test
+    engine: mysql
+    role: testing
+`)
+
+	_, _, err := resolveExecDatabases(dir)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "multiple testing databases")
+	assert.Contains(t, err.Error(), "demo_a_test")
+	assert.Contains(t, err.Error(), "demo_b_test")
+	assert.Contains(t, err.Error(), "remove the stale entries and retry")
+}
+
+func TestResolveExecDatabases_DuplicateApplicationRecordsRefused(t *testing.T) {
+	dir := t.TempDir()
+	writeExecStateFile(t, dir, `db_suffix: top_provider
+databases:
+  - name: demo_one
+    engine: mysql
+    role: application
+  - name: demo_two
+    engine: mysql
+    role: application
+  - name: demo_one_test
+    engine: mysql
+    role: testing
+`)
+
+	_, _, err := resolveExecDatabases(dir)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "multiple application databases")
+	assert.Contains(t, err.Error(), "demo_one")
+	assert.Contains(t, err.Error(), "demo_two")
+}
+
+func TestResolveExecDatabases_UnsupportedRoleRefused(t *testing.T) {
+	dir := t.TempDir()
+	writeExecStateFile(t, dir, `db_suffix: top_provider
+databases:
+  - name: demo_top_provider
+    engine: mysql
+    role: someday-role
+  - name: demo_top_provider_test
+    engine: mysql
+    role: testing
+`)
+
+	_, _, err := resolveExecDatabases(dir)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `unsupported database record role "someday-role"`)
+	assert.Contains(t, err.Error(), "demo_top_provider")
+}
+
+func TestResolveExecDatabases_LegacyStateFailSafeReadOnly(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, config.WriteLocalState(dir, config.LocalState{DbSuffix: "top_provider"}))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, ".env"),
+		[]byte("DB_CONNECTION=mysql\nDB_DATABASE=demo_top_provider\n"), 0o644))
+	before, err := os.ReadFile(filepath.Join(dir, config.LocalStateFile))
+	require.NoError(t, err)
+
+	_, _, err = resolveExecDatabases(dir)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "v1.8")
+	assert.Contains(t, err.Error(), "migrate:fresh")
+	assert.NotContains(t, err.Error(), "shared database")
+
+	after, err := os.ReadFile(filepath.Join(dir, config.LocalStateFile))
+	require.NoError(t, err)
+	assert.Equal(t, before, after, "resolveExecDatabases must never write .anvil.local")
+}
+
+func TestResolveExecDatabases_SharedDbMessage(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, config.WriteLocalState(dir, config.LocalState{DbSuffix: "top_provider"}))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, ".env"),
+		[]byte("DB_CONNECTION=mysql\nDB_DATABASE=demo\n"), 0o644))
+
+	_, _, err := resolveExecDatabases(dir)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "shared database")
+	assert.Contains(t, err.Error(), "v1.8")
+}
+
+func TestResolveExecDatabases_SqliteMessage(t *testing.T) {
+	t.Run("env connection sqlite", func(t *testing.T) {
+		dir := t.TempDir()
+		require.NoError(t, config.WriteLocalState(dir, config.LocalState{DbSuffix: "top_provider"}))
+		require.NoError(t, os.WriteFile(filepath.Join(dir, ".env"),
+			[]byte("DB_CONNECTION=sqlite\n"), 0o644))
+
+		_, _, err := resolveExecDatabases(dir)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "SQLite")
+		assert.Contains(t, err.Error(), "already isolated")
+		assert.NotContains(t, err.Error(), "v1.8")
+	})
+
+	t.Run("recorded sqlite engine beats generic validator", func(t *testing.T) {
+		dir := t.TempDir()
+		writeExecStateFile(t, dir, `db_suffix: top_provider
+databases:
+  - name: demo_top_provider
+    engine: sqlite
+    role: application
+`)
+
+		_, _, err := resolveExecDatabases(dir)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "SQLite")
+		assert.NotContains(t, err.Error(), "unsupported database engine")
+	})
+}
+
+func TestResolveExecDatabases_MultipleEnginesRefused(t *testing.T) {
+	dir := t.TempDir()
+	writeExecStateFile(t, dir, `db_suffix: top_provider
+databases:
+  - name: demo_top_provider
+    engine: mysql
+    role: application
+  - name: demo_top_provider_test
+    engine: pgsql
+    role: testing
+`)
+
+	_, _, err := resolveExecDatabases(dir)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "exactly one supported engine")
+}
+
+func TestResolveExecDatabases_InvalidRecordedNameRefused(t *testing.T) {
+	dir := t.TempDir()
+	writeExecStateFile(t, dir, `db_suffix: top_provider
+databases:
+  - name: bad;name
+    engine: mysql
+    role: testing
+`)
+
+	_, _, err := resolveExecDatabases(dir)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid database name")
+}
+
+func TestChildExitError(t *testing.T) {
+	withMessage := &ChildExitError{Code: 127, Message: "command not found: nope"}
+	assert.Equal(t, "command not found: nope", withMessage.Error())
+
+	wrapped := fmt.Errorf("running child: %w", withMessage)
+	var childErr *ChildExitError
+	require.True(t, errors.As(wrapped, &childErr))
+	assert.Equal(t, 127, childErr.Code)
+	assert.Equal(t, "command not found: nope", childErr.Message)
+
+	bare := &ChildExitError{Code: 7}
+	assert.NotEmpty(t, bare.Error())
+}

--- a/internal/cli/exec_unix.go
+++ b/internal/cli/exec_unix.go
@@ -1,0 +1,23 @@
+//go:build !windows
+
+package cli
+
+import (
+	"fmt"
+	"os/exec"
+	"syscall"
+)
+
+// runChild replaces the anvil process with the child command via execve, so
+// the child directly owns the terminal, signals, stdio, and exit code.
+func runChild(argv []string, env []string) error {
+	path, err := exec.LookPath(argv[0])
+	if err != nil {
+		return childLookPathError(argv[0], err)
+	}
+	if err := syscall.Exec(path, argv, env); err != nil {
+		return &ChildExitError{Code: 126, Message: fmt.Sprintf("executing %s: %v", path, err)}
+	}
+	// Unreachable: a successful Exec never returns.
+	return nil
+}

--- a/internal/cli/exec_unix_test.go
+++ b/internal/cli/exec_unix_test.go
@@ -1,0 +1,106 @@
+//go:build !windows
+
+package cli
+
+import (
+	"bytes"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestFindWorktreeRoot_StatErrorSurfaced needs a permission-denied stat, which
+// os.Chmod cannot produce on Windows; this unix build leg carries the
+// stat-error contract.
+func TestFindWorktreeRoot_StatErrorSurfaced(t *testing.T) {
+	root := t.TempDir()
+	denied := filepath.Join(root, "denied")
+	require.NoError(t, os.MkdirAll(denied, 0o755))
+	require.NoError(t, os.Chmod(denied, 0o000))
+	t.Cleanup(func() {
+		require.NoError(t, os.Chmod(denied, 0o755))
+	})
+
+	_, err := findWorktreeRoot(denied)
+	require.Error(t, err)
+	assert.NotContains(t, err.Error(), "anvil scaffold",
+		"a stat failure must surface as an error, not report not-found")
+}
+
+// TestExecCommand_ExistingNonExecutableFile126 is the B2 real-binary unix leg:
+// an explicit path to an existing file without execute permission must exit
+// 126, not 127.
+func TestExecCommand_ExistingNonExecutableFile126(t *testing.T) {
+	bin := getAnvilBinary(t)
+	dir := t.TempDir()
+	writeExecIntegrationState(t, dir)
+	target := filepath.Join(t.TempDir(), "not-executable.sh")
+	require.NoError(t, os.WriteFile(target, []byte("#!/bin/sh\necho unreachable\n"), 0o644))
+
+	cmd := exec.Command(bin, "exec", "--", target)
+	cmd.Dir = dir
+	cmd.Env = subprocessEnv(t)
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	err := cmd.Run()
+	var exitErr *exec.ExitError
+	require.ErrorAs(t, err, &exitErr)
+	assert.Equal(t, 126, exitErr.ExitCode())
+	assert.Contains(t, stderr.String(), "cannot execute")
+	assert.Contains(t, stderr.String(), target)
+	assert.NotContains(t, stderr.String(), "command not found")
+}
+
+func TestExecCommand_PathResolvedNonExecutableFile126(t *testing.T) {
+	bin := getAnvilBinary(t)
+	dir := t.TempDir()
+	writeExecIntegrationState(t, dir)
+	commandDir := t.TempDir()
+	const commandName = "anvil-non-executable-fixture"
+	target := filepath.Join(commandDir, commandName)
+	require.NoError(t, os.WriteFile(target, []byte("unreachable\n"), 0o644))
+
+	pathValue := commandDir + string(os.PathListSeparator) + os.Getenv("PATH")
+	cmd := exec.Command(bin, "exec", "--", commandName)
+	cmd.Dir = dir
+	cmd.Env = subprocessEnv(t, "PATH="+pathValue)
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	err := cmd.Run()
+	var exitErr *exec.ExitError
+	require.ErrorAs(t, err, &exitErr)
+	assert.Equal(t, 126, exitErr.ExitCode())
+	assert.Contains(t, stderr.String(), "cannot execute")
+	assert.Contains(t, stderr.String(), commandName)
+	assert.NotContains(t, stderr.String(), "command not found")
+}
+
+func TestExecCommand_ExistingDirectory126(t *testing.T) {
+	bin := getAnvilBinary(t)
+	dir := t.TempDir()
+	writeExecIntegrationState(t, dir)
+	target := t.TempDir()
+
+	cmd := exec.Command(bin, "exec", "--", target)
+	cmd.Dir = dir
+	cmd.Env = subprocessEnv(t)
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	err := cmd.Run()
+	var exitErr *exec.ExitError
+	require.ErrorAs(t, err, &exitErr)
+	assert.Equal(t, 126, exitErr.ExitCode())
+	assert.Contains(t, stderr.String(), "cannot execute")
+	assert.Contains(t, stderr.String(), target)
+	assert.NotContains(t, stderr.String(), "command not found")
+}

--- a/internal/cli/exec_windows.go
+++ b/internal/cli/exec_windows.go
@@ -1,0 +1,34 @@
+//go:build windows
+
+package cli
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+)
+
+// runChild runs the child command with wired stdio and propagates its exit
+// code as a typed error. Windows has no execve; anvil stays the parent
+// process, so signal forwarding and job-object management are out of scope
+// for v1.8 (documented limitation).
+func runChild(argv []string, env []string) error {
+	path, err := exec.LookPath(argv[0])
+	if err != nil {
+		return childLookPathError(argv[0], err)
+	}
+	cmd := exec.Command(path, argv[1:]...)
+	cmd.Env = env
+	cmd.Stdin = os.Stdin
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) {
+			return &ChildExitError{Code: exitErr.ExitCode()}
+		}
+		return &ChildExitError{Code: 126, Message: fmt.Sprintf("executing %s: %v", path, err)}
+	}
+	return nil
+}

--- a/internal/cli/exec_windows_test.go
+++ b/internal/cli/exec_windows_test.go
@@ -1,0 +1,81 @@
+//go:build windows
+
+package cli
+
+import (
+	"bytes"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestExecCommand_WindowsCaseVariantEnvReplaced(t *testing.T) {
+	bin := getAnvilBinary(t)
+	dir := t.TempDir()
+	_, testDb := writeExecIntegrationState(t, dir)
+
+	cmd := exec.Command(bin, "exec", "--", helperSelf(t))
+	cmd.Dir = dir
+	cmd.Env = subprocessEnv(t,
+		"db_database=stale_case_variant",
+		"ANVIL_TEST_HELPER=1",
+		"ANVIL_HELPER_MODE=env",
+	)
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	require.NoError(t, cmd.Run(), "stdout: %s\nstderr: %s", stdout.String(), stderr.String())
+	out := stdout.String()
+	assert.Contains(t, out, "DB_DATABASE="+testDb+"\n")
+	assert.NotContains(t, out, "stale_case_variant")
+}
+
+func TestExecCommand_ExistingNonLaunchableFile126(t *testing.T) {
+	bin := getAnvilBinary(t)
+	dir := t.TempDir()
+	writeExecIntegrationState(t, dir)
+	target := filepath.Join(t.TempDir(), "not-launchable.txt")
+	require.NoError(t, os.WriteFile(target, []byte("unreachable\n"), 0o644))
+
+	cmd := exec.Command(bin, "exec", "--", target)
+	cmd.Dir = dir
+	cmd.Env = subprocessEnv(t)
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	err := cmd.Run()
+	var exitErr *exec.ExitError
+	require.ErrorAs(t, err, &exitErr)
+	assert.Equal(t, 126, exitErr.ExitCode())
+	assert.Contains(t, stderr.String(), "cannot execute")
+	assert.Contains(t, stderr.String(), target)
+	assert.NotContains(t, stderr.String(), "command not found")
+}
+
+func TestExecCommand_ExistingDirectory126(t *testing.T) {
+	bin := getAnvilBinary(t)
+	dir := t.TempDir()
+	writeExecIntegrationState(t, dir)
+	target := t.TempDir()
+
+	cmd := exec.Command(bin, "exec", "--", target)
+	cmd.Dir = dir
+	cmd.Env = subprocessEnv(t)
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	err := cmd.Run()
+	var exitErr *exec.ExitError
+	require.ErrorAs(t, err, &exitErr)
+	assert.Equal(t, 126, exitErr.ExitCode())
+	assert.Contains(t, stderr.String(), "cannot execute")
+	assert.Contains(t, stderr.String(), target)
+	assert.NotContains(t, stderr.String(), "command not found")
+}

--- a/internal/cli/exec_windows_test.go
+++ b/internal/cli/exec_windows_test.go
@@ -53,7 +53,7 @@ func TestExecCommand_ExistingNonLaunchableFile126(t *testing.T) {
 	var exitErr *exec.ExitError
 	require.ErrorAs(t, err, &exitErr)
 	assert.Equal(t, 126, exitErr.ExitCode())
-	assert.Contains(t, stderr.String(), "cannot execute")
+	assert.Contains(t, stderr.String(), "executing "+target)
 	assert.Contains(t, stderr.String(), target)
 	assert.NotContains(t, stderr.String(), "command not found")
 }

--- a/internal/cli/exit_error.go
+++ b/internal/cli/exit_error.go
@@ -1,0 +1,17 @@
+package cli
+
+import "fmt"
+
+// ChildExitError carries a child process's exit code (and optional message)
+// to cmd/anvil/main.go, which maps it to os.Exit — RunE never exits directly.
+type ChildExitError struct {
+	Code    int
+	Message string
+}
+
+func (e *ChildExitError) Error() string {
+	if e.Message != "" {
+		return e.Message
+	}
+	return fmt.Sprintf("exit status %d", e.Code)
+}

--- a/internal/cli/main_test.go
+++ b/internal/cli/main_test.go
@@ -1,0 +1,92 @@
+package cli
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strconv"
+	"testing"
+)
+
+// TestMain builds the real anvil binary once and publishes its path through
+// the test-only ANVIL_TEST_BIN environment key — no package variable. When
+// re-invoked with ANVIL_TEST_HELPER=1 the test binary acts as the child
+// process for `anvil exec` integration tests instead of running tests.
+func TestMain(m *testing.M) {
+	if os.Getenv("ANVIL_TEST_HELPER") == "1" {
+		helperMain() // dispatches on ANVIL_HELPER_MODE; calls os.Exit — never returns
+	}
+
+	dir, err := os.MkdirTemp("", "anvil-test-bin")
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "creating test binary dir:", err)
+		os.Exit(1)
+	}
+	bin := filepath.Join(dir, testBinaryName())
+	buildCmd := exec.Command("go", "build", "-o", bin, "github.com/naoray/anvil/cmd/anvil")
+	if buildOutput, buildErr := buildCmd.CombinedOutput(); buildErr != nil {
+		fmt.Fprintf(os.Stderr, "building anvil test binary: %v\n%s", buildErr, buildOutput)
+		removeTestBinaryDir(dir)
+		os.Exit(1)
+	}
+	if err := os.Setenv("ANVIL_TEST_BIN", bin); err != nil {
+		fmt.Fprintln(os.Stderr, "setting ANVIL_TEST_BIN:", err)
+		removeTestBinaryDir(dir)
+		os.Exit(1)
+	}
+
+	code := m.Run()
+	// Cleanup must happen before os.Exit — a defer would never run.
+	removeTestBinaryDir(dir)
+	os.Exit(code)
+}
+
+func testBinaryName() string {
+	if runtime.GOOS == "windows" {
+		return "anvil.exe"
+	}
+	return "anvil"
+}
+
+func removeTestBinaryDir(dir string) {
+	if err := os.RemoveAll(dir); err != nil {
+		fmt.Fprintln(os.Stderr, "cleanup of test binary dir failed:", err)
+	}
+}
+
+// helperMain implements the pure-Go child processes for exec integration
+// tests (no sh fixtures, no /tmp assumptions). Every branch exits.
+func helperMain() {
+	switch mode := os.Getenv("ANVIL_HELPER_MODE"); mode {
+	case "env":
+		for _, key := range []string{"DB_DATABASE", "ANVIL_DB_DATABASE", "ANVIL_TEST_DB_DATABASE"} {
+			fmt.Printf("%s=%s\n", key, os.Getenv(key))
+		}
+		for i, arg := range os.Args[1:] {
+			fmt.Printf("argv[%d]=%s\n", i, arg)
+		}
+		os.Exit(0)
+	case "exit":
+		code, err := strconv.Atoi(os.Getenv("ANVIL_HELPER_EXIT"))
+		if err != nil {
+			fmt.Fprintln(os.Stderr, "invalid ANVIL_HELPER_EXIT:", err)
+			os.Exit(1)
+		}
+		os.Exit(code)
+	case "cat":
+		if _, err := io.Copy(os.Stdout, os.Stdin); err != nil {
+			fmt.Fprintln(os.Stderr, "copying stdin to stdout:", err)
+			os.Exit(1)
+		}
+		os.Exit(0)
+	case "stderr":
+		fmt.Fprint(os.Stderr, os.Getenv("ANVIL_HELPER_STDERR"))
+		os.Exit(0)
+	default:
+		fmt.Fprintf(os.Stderr, "unknown ANVIL_HELPER_MODE %q\n", mode)
+		os.Exit(1)
+	}
+}

--- a/internal/cli/remove.go
+++ b/internal/cli/remove.go
@@ -4,18 +4,119 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/spf13/cobra"
 
+	"github.com/naoray/anvil/internal/config"
 	anvilerrors "github.com/naoray/anvil/internal/errors"
 	"github.com/naoray/anvil/internal/git"
+	"github.com/naoray/anvil/internal/scaffold"
 	"github.com/naoray/anvil/internal/ui"
 )
 
-var removeCmd = &cobra.Command{
-	Use:   "remove [FOLDER]",
-	Short: "Remove a worktree with cleanup",
-	Long: `Removes a worktree and runs preset-defined cleanup steps.
+func planRemoveCleanup(
+	state *config.LocalState,
+	stateErr error,
+	keepDB, dryRun, force bool,
+) (scaffold.CleanupOptions, []string, error) {
+	opts := scaffold.CleanupOptions{DryRun: dryRun}
+	if stateErr != nil {
+		if !force {
+			return opts, nil, fmt.Errorf(
+				"cannot read .anvil.local (%v) — it is the only record of this worktree's databases; fix the file, or rerun with --force to remove the worktree anyway (databases will be left untouched and unrecorded)",
+				stateErr,
+			)
+		}
+		opts.SkipDatabaseCleanup = true
+		return opts, []string{fmt.Sprintf(
+			"WARNING: cannot read .anvil.local (%v); proceeding because --force was set; databases will be left untouched and unrecorded",
+			stateErr,
+		)}, nil
+	}
+	if state == nil {
+		state = &config.LocalState{}
+	}
+	if err := config.ValidateOwnedDatabases(state.Databases); err != nil {
+		if !force {
+			return opts, nil, fmt.Errorf(
+				"invalid database records in .anvil.local (%v) — no databases were dropped; fix the records, or rerun with --force to remove the worktree anyway (databases will be left untouched and unrecorded)",
+				err,
+			)
+		}
+		opts.SkipDatabaseCleanup = true
+		return opts, []string{fmt.Sprintf(
+			"WARNING: invalid database records in .anvil.local (%v); proceeding because --force was set; databases will be left untouched and unrecorded",
+			err,
+		)}, nil
+	}
+	if !keepDB {
+		return opts, nil, nil
+	}
+
+	opts.SkipDatabaseCleanup = true
+	messages := make([]string, 0, 2)
+	if len(state.Databases) > 0 {
+		names := make([]string, 0, len(state.Databases))
+		seen := make(map[string]struct{}, len(state.Databases))
+		for _, database := range state.Databases {
+			if _, exists := seen[database.Name]; exists {
+				continue
+			}
+			seen[database.Name] = struct{}{}
+			names = append(names, database.Name)
+		}
+		messages = append(messages, fmt.Sprintf(
+			"Preserving databases: %s (parallel worker databases are kept too; drop manually when done)",
+			strings.Join(names, ", "),
+		))
+	} else if state.DbSuffix != "" {
+		messages = append(messages, fmt.Sprintf(
+			"Preserving databases matching suffix '%s' (legacy worktree — exact names unknown)",
+			state.DbSuffix,
+		))
+	}
+	if dryRun {
+		messages = append(messages, "[DRY RUN] database cleanup would be skipped (--keep-db)")
+	}
+	return opts, messages, nil
+}
+
+type removeCommandDependencies struct {
+	openProject      func() (*ProjectContext, error)
+	getwd            func() (string, error)
+	getDefaultBranch func(string) (string, error)
+	listWorktrees    func(string, string, string) ([]git.Worktree, error)
+	branchExists     func(string, string) bool
+	removeWorktree   func(string, string, bool) error
+	deleteBranch     func(string, string, bool) error
+	readLocalState   func(string) (*config.LocalState, error)
+	scaffoldManager  func(*ProjectContext) *scaffold.ScaffoldManager
+	detectPreset     func(*ProjectContext, string) string
+}
+
+func defaultRemoveCommandDependencies() removeCommandDependencies {
+	return removeCommandDependencies{
+		openProject:      OpenProjectFromCWD,
+		getwd:            os.Getwd,
+		getDefaultBranch: git.GetDefaultBranch,
+		listWorktrees:    git.ListWorktreesDetailed,
+		branchExists:     git.BranchExists,
+		removeWorktree:   git.RemoveWorktree,
+		deleteBranch:     git.DeleteBranch,
+		readLocalState:   config.ReadLocalState,
+		scaffoldManager:  func(pc *ProjectContext) *scaffold.ScaffoldManager { return pc.ScaffoldManager() },
+		detectPreset:     func(pc *ProjectContext, path string) string { return pc.PresetManager().Detect(path) },
+	}
+}
+
+var removeCmd = newRemoveCommand(defaultRemoveCommandDependencies())
+
+func newRemoveCommand(deps removeCommandDependencies) *cobra.Command {
+	command := &cobra.Command{
+		Use:   "remove [FOLDER]",
+		Short: "Remove a worktree with cleanup",
+		Long: `Removes a worktree and runs preset-defined cleanup steps.
 
 Arguments:
   FOLDER  Name of the worktree folder to remove (e.g., feature-test-change)
@@ -23,95 +124,106 @@ Arguments:
 Cleanup steps may include:
   - Removing Herd site links
   - Database cleanup prompts`,
-	Args:              cobra.MaximumNArgs(1),
-	ValidArgsFunction: completeWorktreeNames,
-	RunE: func(cmd *cobra.Command, args []string) error {
-		pc, err := OpenProjectFromCWD()
-		if err != nil {
-			return err
-		}
+		Args:              cobra.MaximumNArgs(1),
+		ValidArgsFunction: completeWorktreeNames,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			pc, err := deps.openProject()
+			if err != nil {
+				return err
+			}
 
-		force := mustGetBool(cmd, "force")
-		dryRun := mustGetBool(cmd, "dry-run")
-		verbose := mustGetBool(cmd, "verbose")
-		quiet := mustGetBool(cmd, "quiet")
+			force := mustGetBool(cmd, "force")
+			dryRun := mustGetBool(cmd, "dry-run")
+			verbose := mustGetBool(cmd, "verbose")
+			quiet := mustGetBool(cmd, "quiet")
+			keepDB := mustGetBool(cmd, "keep-db")
 
-		currentWorktreePath, err := os.Getwd()
-		if err != nil {
-			return fmt.Errorf("getting current directory: %w", err)
-		}
+			currentWorktreePath, err := deps.getwd()
+			if err != nil {
+				return fmt.Errorf("getting current directory: %w", err)
+			}
 
-		defaultBranch, err := git.GetDefaultBranch(pc.GitDir)
-		if err != nil {
-			return fmt.Errorf("getting default branch: %w", err)
-		}
+			defaultBranch, err := deps.getDefaultBranch(pc.GitDir)
+			if err != nil {
+				return fmt.Errorf("getting default branch: %w", err)
+			}
 
-		worktrees, err := git.ListWorktreesDetailed(pc.GitDir, currentWorktreePath, defaultBranch)
-		if err != nil {
-			return fmt.Errorf("listing worktrees: %w", err)
-		}
+			worktrees, err := deps.listWorktrees(pc.GitDir, currentWorktreePath, defaultBranch)
+			if err != nil {
+				return fmt.Errorf("listing worktrees: %w", err)
+			}
 
-		var targetWorktree *git.Worktree
+			var targetWorktree *git.Worktree
 
-		if len(args) > 0 {
-			folderName := args[0]
-			for _, wt := range worktrees {
-				if filepath.Base(wt.Path) == folderName {
-					targetWorktree = &wt
-					break
+			if len(args) > 0 {
+				folderName := args[0]
+				for _, wt := range worktrees {
+					if filepath.Base(wt.Path) == folderName {
+						targetWorktree = &wt
+						break
+					}
 				}
-			}
-			if targetWorktree == nil {
-				return fmt.Errorf("worktree '%s' not found: %w", folderName, anvilerrors.ErrWorktreeNotFound)
-			}
-		} else if ui.IsInteractive() {
-			selected, err := ui.SelectWorktreeToRemove(worktrees)
-			if err != nil {
-				return fmt.Errorf("selecting worktree: %w", err)
-			}
-			targetWorktree = selected
-		} else {
-			return fmt.Errorf("worktree folder name required (run interactively or use --force to skip prompts)")
-		}
-
-		if targetWorktree.IsMain {
-			return fmt.Errorf("cannot remove main worktree")
-		}
-
-		ui.PrintInfo(fmt.Sprintf("Removing %s at %s", targetWorktree.Branch, targetWorktree.Path))
-
-		deleteBranch := false
-		if !force {
-			if !ui.IsInteractive() {
-				return fmt.Errorf("worktree removal requires confirmation (use --force to skip)")
-			}
-
-			ui.PrintInfo("This will run cleanup steps.")
-			confirmed, err := ui.Confirm(fmt.Sprintf("Remove worktree '%s'?", targetWorktree.Branch))
-			if err != nil {
-				return fmt.Errorf("confirmation: %w", err)
-			}
-			if !confirmed {
-				ui.PrintInfo("Cancelled.")
-				return nil
-			}
-
-			if git.BranchExists(pc.GitDir, targetWorktree.Branch) {
-				deleteBranch, err = ui.Confirm(fmt.Sprintf("Also delete branch '%s'?", targetWorktree.Branch))
+				if targetWorktree == nil {
+					return fmt.Errorf("worktree '%s' not found: %w", folderName, anvilerrors.ErrWorktreeNotFound)
+				}
+			} else if ui.IsInteractive() {
+				selected, err := ui.SelectWorktreeToRemove(worktrees)
 				if err != nil {
-					return fmt.Errorf("branch deletion confirmation: %w", err)
+					return fmt.Errorf("selecting worktree: %w", err)
 				}
+				targetWorktree = selected
+			} else {
+				return fmt.Errorf("worktree folder name required (run interactively or use --force to skip prompts)")
 			}
-		} else {
-			deleteBranch = mustGetBool(cmd, "delete-branch")
-		}
 
-		ui.PrintStep("Removing worktree")
+			if targetWorktree.IsMain {
+				return fmt.Errorf("cannot remove main worktree")
+			}
 
-		if !dryRun {
+			state, stateErr := deps.readLocalState(targetWorktree.Path)
+			cleanupOpts, cleanupMessages, err := planRemoveCleanup(state, stateErr, keepDB, dryRun, force)
+			if err != nil {
+				return err
+			}
+			cleanupOpts.Verbose = verbose
+			cleanupOpts.Quiet = quiet
+			for _, message := range cleanupMessages {
+				ui.PrintInfo(message)
+			}
+
+			ui.PrintInfo(fmt.Sprintf("Removing %s at %s", targetWorktree.Branch, targetWorktree.Path))
+
+			deleteBranch := false
+			if !force {
+				if !ui.IsInteractive() {
+					return fmt.Errorf("worktree removal requires confirmation (use --force to skip)")
+				}
+
+				ui.PrintInfo("This will run cleanup steps.")
+				confirmed, err := ui.Confirm(fmt.Sprintf("Remove worktree '%s'?", targetWorktree.Branch))
+				if err != nil {
+					return fmt.Errorf("confirmation: %w", err)
+				}
+				if !confirmed {
+					ui.PrintInfo("Cancelled.")
+					return nil
+				}
+
+				if deps.branchExists(pc.GitDir, targetWorktree.Branch) {
+					deleteBranch, err = ui.Confirm(fmt.Sprintf("Also delete branch '%s'?", targetWorktree.Branch))
+					if err != nil {
+						return fmt.Errorf("branch deletion confirmation: %w", err)
+					}
+				}
+			} else {
+				deleteBranch = mustGetBool(cmd, "delete-branch")
+			}
+
+			ui.PrintStep("Removing worktree")
+
 			preset := pc.Config.Preset
 			if preset == "" {
-				preset = pc.PresetManager().Detect(targetWorktree.Path)
+				preset = deps.detectPreset(pc, targetWorktree.Path)
 			}
 
 			if verbose && preset != "" {
@@ -120,46 +232,57 @@ Cleanup steps may include:
 
 			if preset != "" {
 				siteName := filepath.Base(targetWorktree.Path)
-				if err := pc.ScaffoldManager().RunCleanup(targetWorktree.Path, targetWorktree.Branch, "", siteName, preset, pc.Config, false, verbose, quiet); err != nil {
+				if err := deps.scaffoldManager(pc).RunCleanupWithOptions(
+					targetWorktree.Path,
+					targetWorktree.Branch,
+					"",
+					siteName,
+					preset,
+					pc.Config,
+					cleanupOpts,
+				); err != nil {
 					ui.PrintErrorWithHint("Cleanup failed", err.Error())
 				}
 			}
 
-			if err := git.RemoveWorktree(pc.GitDir, targetWorktree.Path, true); err != nil {
-				return fmt.Errorf("removing worktree: %w", err)
-			}
-			ui.PrintSuccessPath("Removed", targetWorktree.Path)
+			if !dryRun {
+				if err := deps.removeWorktree(pc.GitDir, targetWorktree.Path, true); err != nil {
+					return fmt.Errorf("removing worktree: %w", err)
+				}
+				ui.PrintSuccessPath("Removed", targetWorktree.Path)
 
-			if deleteBranch && git.BranchExists(pc.GitDir, targetWorktree.Branch) {
-				if err := git.DeleteBranch(pc.GitDir, targetWorktree.Branch, true); err != nil {
-					ui.PrintErrorWithHint("Failed to delete branch", err.Error())
-				} else {
-					ui.PrintSuccess(fmt.Sprintf("Deleted branch '%s'", targetWorktree.Branch))
+				if deleteBranch && deps.branchExists(pc.GitDir, targetWorktree.Branch) {
+					if err := deps.deleteBranch(pc.GitDir, targetWorktree.Branch, true); err != nil {
+						ui.PrintErrorWithHint("Failed to delete branch", err.Error())
+					} else {
+						ui.PrintSuccess(fmt.Sprintf("Deleted branch '%s'", targetWorktree.Branch))
+					}
+				}
+
+				parentDir := filepath.Dir(targetWorktree.Path)
+				entries, err := os.ReadDir(parentDir)
+				if err == nil && len(entries) == 0 {
+					if err := os.Remove(parentDir); err != nil {
+						ui.PrintErrorWithHint(fmt.Sprintf("Could not remove empty directory %s", parentDir), err.Error())
+					}
+				}
+			} else {
+				ui.PrintInfo("[DRY RUN] Would remove worktree")
+				if deleteBranch {
+					ui.PrintInfo("[DRY RUN] Would delete branch")
 				}
 			}
 
-			parentDir := filepath.Dir(targetWorktree.Path)
-			entries, err := os.ReadDir(parentDir)
-			if err == nil && len(entries) == 0 {
-				if err := os.Remove(parentDir); err != nil {
-					ui.PrintErrorWithHint(fmt.Sprintf("Could not remove empty directory %s", parentDir), err.Error())
-				}
-			}
-		} else {
-			ui.PrintInfo("[DRY RUN] Would run cleanup and remove worktree")
-			if deleteBranch {
-				ui.PrintInfo("[DRY RUN] Would delete branch")
-			}
-		}
-
-		ui.PrintDone("Worktree removed")
-		return nil
-	},
+			ui.PrintDone("Worktree removed")
+			return nil
+		},
+	}
+	command.Flags().BoolP("force", "f", false, "Skip confirmation and cleanup prompts")
+	command.Flags().Bool("delete-branch", false, "Also delete the branch after removing worktree")
+	command.Flags().Bool("keep-db", false, "Keep owned databases and parallel-worker databases")
+	return command
 }
 
 func init() {
 	rootCmd.AddCommand(removeCmd)
-
-	removeCmd.Flags().BoolP("force", "f", false, "Skip confirmation and cleanup prompts")
-	removeCmd.Flags().Bool("delete-branch", false, "Also delete the branch after removing worktree")
 }

--- a/internal/cli/remove_integration_test.go
+++ b/internal/cli/remove_integration_test.go
@@ -1,0 +1,190 @@
+package cli
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"io/fs"
+	"net"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/naoray/anvil/internal/config"
+)
+
+func runGitCommand(t *testing.T, dir string, args ...string) {
+	t.Helper()
+	fullArgs := append([]string{
+		"-c", "user.name=anvil-test",
+		"-c", "user.email=anvil-test@example.com",
+		"-c", "commit.gpgsign=false",
+	}, args...)
+	cmd := exec.Command("git", fullArgs...)
+	cmd.Dir = dir
+	output, err := cmd.CombinedOutput()
+	require.NoError(t, err, "git %v: %s", args, output)
+}
+
+// snapshotTree captures every file under root as relpath -> contents so a
+// dry-run can be proven byte-identical.
+func snapshotTree(t *testing.T, root string) map[string]string {
+	t.Helper()
+	snapshot := make(map[string]string)
+	err := filepath.WalkDir(root, func(path string, entry fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if entry.IsDir() {
+			return nil
+		}
+		contents, readErr := os.ReadFile(path)
+		if readErr != nil {
+			return readErr
+		}
+		rel, relErr := filepath.Rel(root, path)
+		if relErr != nil {
+			return relErr
+		}
+		snapshot[rel] = string(contents)
+		return nil
+	})
+	require.NoError(t, err)
+	return snapshot
+}
+
+// TestRemoveBinary_DryRunLiveEnumerationNoMutation is the B1-mandated
+// binary-level test: `remove --dry-run` through the shipped binary must
+// execute DbDestroyStep.Run live (proven by the cannot-enumerate note, which
+// only prints when the step attempts the worker-family listing), print the
+// exact owned names, exit successfully, and mutate nothing.
+//
+// The fixture pins db.destroy to a controlled loopback listener that accepts
+// and immediately closes every connection. This makes the cannot-enumerate
+// branch deterministic without consulting ambient PostgreSQL state.
+func TestRemoveBinary_DryRunLiveEnumerationNoMutation(t *testing.T) {
+	bin := getAnvilBinary(t)
+	base := t.TempDir()
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	accepted := make(chan struct{}, 1)
+	serveDone := make(chan error, 1)
+	t.Cleanup(func() {
+		if closeErr := listener.Close(); closeErr != nil && !errors.Is(closeErr, net.ErrClosed) {
+			t.Errorf("closing fixture listener: %v", closeErr)
+		}
+		select {
+		case serveErr := <-serveDone:
+			if serveErr != nil {
+				t.Errorf("serving fixture listener: %v", serveErr)
+			}
+		case <-time.After(time.Second):
+			t.Error("fixture listener did not stop")
+		}
+	})
+	go func() {
+		for {
+			conn, acceptErr := listener.Accept()
+			if acceptErr != nil {
+				if errors.Is(acceptErr, net.ErrClosed) {
+					serveDone <- nil
+				} else {
+					serveDone <- acceptErr
+				}
+				return
+			}
+			select {
+			case accepted <- struct{}{}:
+			default:
+			}
+			if closeErr := conn.Close(); closeErr != nil {
+				serveDone <- closeErr
+				return
+			}
+		}
+	}()
+	port := listener.Addr().(*net.TCPAddr).Port
+
+	repoDir := filepath.Join(base, "projects", "demo")
+	require.NoError(t, os.MkdirAll(repoDir, 0o755))
+	runGitCommand(t, base, "init", "-b", "main", repoDir)
+	require.NoError(t, os.WriteFile(filepath.Join(repoDir, "README.md"), []byte("fixture\n"), 0o644))
+	runGitCommand(t, repoDir, "add", ".")
+	runGitCommand(t, repoDir, "commit", "-m", "fixture commit")
+
+	worktreeBase := filepath.Join(base, "worktrees")
+	worktreeDir := filepath.Join(worktreeBase, "demo", "feature-x")
+	require.NoError(t, os.MkdirAll(filepath.Dir(worktreeDir), 0o755))
+	runGitCommand(t, repoDir, "worktree", "add", worktreeDir, "-b", "feature-x")
+
+	appDb := "demo_pg_fixture"
+	testDb := "demo_pg_fixture_test"
+	require.NoError(t, config.WriteLocalState(worktreeDir, config.LocalState{
+		DbSuffix: "pg_fixture",
+		Databases: []config.OwnedDatabase{
+			{Name: appDb, Engine: "pgsql", Role: config.DbRoleApplication},
+			{Name: testDb, Engine: "pgsql", Role: config.DbRoleTesting},
+		},
+	}))
+
+	configHome := filepath.Join(base, "config-home")
+	require.NoError(t, os.MkdirAll(filepath.Join(configHome, "anvil"), 0o755))
+	globalConfig := fmt.Sprintf(`default_branch: main
+worktree_base: %q
+setup_complete: true
+projects:
+  demo:
+    path: %q
+    default_branch: main
+    preset: controlled-test
+    site_name: demo
+    cleanup:
+      steps:
+        - name: db.destroy
+          args:
+            - --host
+            - 127.0.0.1
+            - --port
+            - %q
+`, worktreeBase, repoDir, strconv.Itoa(port))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(configHome, "anvil", config.ProjectConfigFile),
+		[]byte(globalConfig), 0o644))
+
+	before := snapshotTree(t, worktreeDir)
+
+	cmd := exec.Command(bin, "remove", "feature-x", "--dry-run", "--force")
+	cmd.Dir = repoDir
+	cmd.Env = subprocessEnv(t, "XDG_CONFIG_HOME="+configHome)
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	runErr := cmd.Run()
+	require.NoError(t, runErr,
+		"remove --dry-run must exit successfully\nstdout: %s\nstderr: %s", stdout.String(), stderr.String())
+	select {
+	case <-accepted:
+	case <-time.After(time.Second):
+		t.Fatal("controlled database endpoint was not contacted")
+	}
+	combined := stdout.String() + stderr.String()
+
+	assert.Contains(t, combined, "Would drop database: "+appDb+"\n")
+	assert.Contains(t, combined, "Would drop database: "+testDb+"\n")
+	// This note is printed only after DbDestroyStep.Run attempted the live
+	// worker-family listing through the shipped binary — the B1 evidence that
+	// dry-run reaches the selector; drops are structurally impossible because
+	// the server is unreachable.
+	assert.Contains(t, combined, "cannot enumerate parallel-worker databases:")
+
+	require.DirExists(t, worktreeDir, "dry-run must not remove the worktree")
+	after := snapshotTree(t, worktreeDir)
+	assert.Equal(t, before, after, "dry-run must leave the worktree byte-identical")
+}

--- a/internal/cli/remove_test.go
+++ b/internal/cli/remove_test.go
@@ -3,17 +3,195 @@ package cli
 import (
 	"bufio"
 	"bytes"
+	"errors"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
 
+	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/naoray/anvil/internal/config"
 	"github.com/naoray/anvil/internal/git"
+	"github.com/naoray/anvil/internal/scaffold"
+	"github.com/naoray/anvil/internal/scaffold/steps"
+	"github.com/naoray/anvil/internal/scaffold/types"
 )
+
+type removeTestRegistry struct {
+	client *steps.MockDatabaseClient
+	output *bytes.Buffer
+}
+
+func (r *removeTestRegistry) Create(name string, cfg config.StepConfig) (types.ScaffoldStep, error) {
+	if name != config.StepDbDestroy {
+		return nil, errors.New("unexpected cleanup step: " + name)
+	}
+	return steps.NewDbDestroyStepWithFactoryAndWriter(cfg, steps.MockClientFactory(r.client), r.output), nil
+}
+
+func (r *removeTestRegistry) ListRegistered() []string {
+	return []string{config.StepDbDestroy}
+}
+
+type removeTestPreset struct{}
+
+func (removeTestPreset) Name() string                      { return "remove-test" }
+func (removeTestPreset) Detect(string) bool                { return false }
+func (removeTestPreset) DefaultSteps() []config.StepConfig { return nil }
+func (removeTestPreset) CleanupSteps() []config.CleanupStep {
+	return []config.CleanupStep{{Name: config.StepDbDestroy}}
+}
+
+func TestRemoveCommand_DryRunEnumeratesExactDropSet(t *testing.T) {
+	worktreePath := t.TempDir()
+	state := config.LocalState{Databases: []config.OwnedDatabase{
+		{Name: "app_top_provider", Engine: "mysql", Role: config.DbRoleApplication},
+		{Name: "app_top_provider_test", Engine: "mysql", Role: config.DbRoleTesting},
+	}}
+	require.NoError(t, config.WriteLocalState(worktreePath, state))
+	statePath := filepath.Join(worktreePath, ".anvil.local")
+	stateBefore, err := os.ReadFile(statePath)
+	require.NoError(t, err)
+
+	client := steps.NewMockDatabaseClient()
+	for _, name := range []string{
+		"app_top_provider",
+		"app_top_provider_test",
+		"app_top_provider_test_1",
+		"app_top_provider_test_2",
+		"app_top_provider_test_test_1",
+		"unrelated_test_1",
+	} {
+		client.AddDatabase(name)
+	}
+	var cleanupOutput bytes.Buffer
+	manager := scaffold.NewScaffoldManagerWithRegistry(&removeTestRegistry{client: client, output: &cleanupOutput})
+	manager.RegisterPreset(removeTestPreset{})
+	pc := &ProjectContext{GitDir: "git-dir", Config: &config.Config{Preset: "remove-test"}}
+	removeCalls := 0
+	deps := removeCommandDependencies{
+		openProject:      func() (*ProjectContext, error) { return pc, nil },
+		getwd:            func() (string, error) { return "/main", nil },
+		getDefaultBranch: func(string) (string, error) { return "main", nil },
+		listWorktrees: func(string, string, string) ([]git.Worktree, error) {
+			return []git.Worktree{{Path: worktreePath, Branch: "agent/test"}}, nil
+		},
+		branchExists: func(string, string) bool { return false },
+		removeWorktree: func(string, string, bool) error {
+			removeCalls++
+			return nil
+		},
+		deleteBranch:    func(string, string, bool) error { return nil },
+		readLocalState:  config.ReadLocalState,
+		scaffoldManager: func(*ProjectContext) *scaffold.ScaffoldManager { return manager },
+		detectPreset:    func(*ProjectContext, string) string { return "remove-test" },
+	}
+
+	root := &cobra.Command{Use: "anvil"}
+	root.PersistentFlags().Bool("dry-run", false, "")
+	root.PersistentFlags().Bool("verbose", false, "")
+	root.PersistentFlags().Bool("quiet", false, "")
+	root.AddCommand(newRemoveCommand(deps))
+	root.SetArgs([]string{"remove", filepath.Base(worktreePath), "--dry-run", "--force", "--quiet"})
+
+	require.NoError(t, root.Execute())
+	assert.Equal(t, "Would drop database: app_top_provider\n"+
+		"Would drop database: app_top_provider_test\n"+
+		"Would drop database: app_top_provider_test_1\n"+
+		"Would drop database: app_top_provider_test_2\n"+
+		"Would drop database: app_top_provider_test_test_1\n", cleanupOutput.String())
+	assert.Equal(t, []string{`app\_top\_provider\_test\_%`, `app\_top\_provider\_test\_test\_%`}, client.GetListCalls())
+	assert.Empty(t, client.GetDropCalls())
+	assert.Zero(t, removeCalls)
+	_, err = os.Stat(worktreePath)
+	require.NoError(t, err)
+	stateAfter, err := os.ReadFile(statePath)
+	require.NoError(t, err)
+	assert.Equal(t, stateBefore, stateAfter)
+}
+
+func TestPlanRemoveCleanup_KeepDbListsPreservedNames(t *testing.T) {
+	state := &config.LocalState{Databases: []config.OwnedDatabase{
+		{Name: "app_top_provider", Engine: "mysql", Role: config.DbRoleApplication},
+		{Name: "app_top_provider_test", Engine: "mysql", Role: config.DbRoleTesting},
+		{Name: "app_top_provider", Engine: "mysql", Role: config.DbRoleApplication},
+	}}
+
+	opts, messages, err := planRemoveCleanup(state, nil, true, false, false)
+
+	require.NoError(t, err)
+	assert.True(t, opts.SkipDatabaseCleanup)
+	assert.Equal(t, []string{
+		"Preserving databases: app_top_provider, app_top_provider_test (parallel worker databases are kept too; drop manually when done)",
+	}, messages)
+}
+
+func TestPlanRemoveCleanup_KeepDbLegacySuffixPattern(t *testing.T) {
+	opts, messages, err := planRemoveCleanup(&config.LocalState{DbSuffix: "top_provider"}, nil, true, false, false)
+
+	require.NoError(t, err)
+	assert.True(t, opts.SkipDatabaseCleanup)
+	assert.Equal(t, []string{
+		"Preserving databases matching suffix 'top_provider' (legacy worktree — exact names unknown)",
+	}, messages)
+}
+
+func TestPlanRemoveCleanup_KeepDbUnreadableStateHardStopsUnlessForce(t *testing.T) {
+	stateErr := errors.New("permission denied")
+
+	_, _, err := planRemoveCleanup(nil, stateErr, true, false, false)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "cannot read .anvil.local")
+	assert.Contains(t, err.Error(), "--force")
+
+	opts, messages, err := planRemoveCleanup(nil, stateErr, true, false, true)
+	require.NoError(t, err)
+	assert.True(t, opts.SkipDatabaseCleanup)
+	require.Len(t, messages, 1)
+	assert.Contains(t, messages[0], "WARNING")
+	assert.Contains(t, messages[0], "databases will be left untouched and unrecorded")
+}
+
+func TestPlanRemoveCleanup_InvalidOwnedStateHardStopsUnlessForce(t *testing.T) {
+	state := &config.LocalState{Databases: []config.OwnedDatabase{
+		{Name: "app_top_provider", Engine: "mysql", Role: "unknown"},
+		{Name: "app_top_provider_test", Engine: "pgsql", Role: config.DbRoleTesting},
+	}}
+
+	_, _, err := planRemoveCleanup(state, nil, false, false, false)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid database records in .anvil.local")
+	assert.Contains(t, err.Error(), "--force")
+
+	opts, messages, err := planRemoveCleanup(state, nil, false, false, true)
+	require.NoError(t, err)
+	assert.True(t, opts.SkipDatabaseCleanup)
+	require.Len(t, messages, 1)
+	assert.Contains(t, messages[0], "WARNING")
+	assert.Contains(t, messages[0], "databases will be left untouched and unrecorded")
+}
+
+func TestPlanRemoveCleanup_DryRunPropagatesDryRunTrue(t *testing.T) {
+	opts, messages, err := planRemoveCleanup(&config.LocalState{}, nil, false, true, false)
+
+	require.NoError(t, err)
+	assert.True(t, opts.DryRun)
+	assert.False(t, opts.SkipDatabaseCleanup)
+	assert.Empty(t, messages)
+}
+
+func TestPlanRemoveCleanup_DryRunKeepDbMessage(t *testing.T) {
+	opts, messages, err := planRemoveCleanup(&config.LocalState{DbSuffix: "top_provider"}, nil, true, true, false)
+
+	require.NoError(t, err)
+	assert.True(t, opts.DryRun)
+	assert.True(t, opts.SkipDatabaseCleanup)
+	assert.Equal(t, "[DRY RUN] database cleanup would be skipped (--keep-db)", messages[len(messages)-1])
+}
 
 func TestRemoveCmd_PreventsMainWorktreeDeletion(t *testing.T) {
 	repoDir := t.TempDir()

--- a/internal/cli/rescaffold_regression_test.go
+++ b/internal/cli/rescaffold_regression_test.go
@@ -1,0 +1,125 @@
+package cli
+
+import (
+	"bytes"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/naoray/anvil/internal/config"
+	"github.com/naoray/anvil/internal/scaffold"
+	"github.com/naoray/anvil/internal/scaffold/steps"
+	"github.com/naoray/anvil/internal/scaffold/types"
+)
+
+type pgRegressionRegistry struct {
+	factory steps.DatabaseClientFactory
+}
+
+func (r *pgRegressionRegistry) Create(name string, cfg config.StepConfig) (types.ScaffoldStep, error) {
+	if name != config.StepDbCreate {
+		return nil, fmt.Errorf("unexpected step %q in pg regression fixture", name)
+	}
+	return steps.NewDbCreateStepWithFactory(cfg, r.factory), nil
+}
+
+func (r *pgRegressionRegistry) ListRegistered() []string {
+	return []string{config.StepDbCreate}
+}
+
+type pgRegressionPreset struct{}
+
+func (pgRegressionPreset) Name() string       { return "pg-regression" }
+func (pgRegressionPreset) Detect(string) bool { return false }
+func (pgRegressionPreset) DefaultSteps() []config.StepConfig {
+	return []config.StepConfig{
+		{Name: config.StepDbCreate, Type: "pgsql"},
+		{Name: config.StepDbCreate, Type: "pgsql", Role: config.DbRoleTesting},
+	}
+}
+func (pgRegressionPreset) CleanupSteps() []config.CleanupStep { return nil }
+
+// TestPostgresRescaffold_IdempotentEndToEnd is the CB2/P2-mandated cascade
+// regression (PG-contract): a second scaffold over the same worktree must load
+// the persisted suffix, treat both DatabaseExistsError results as idempotent
+// success, keep exactly one application and one testing record with unchanged
+// names, leave exec resolution working, and keep cleanup selection correct.
+func TestPostgresRescaffold_IdempotentEndToEnd(t *testing.T) {
+	dir := t.TempDir()
+	client := steps.NewMockDatabaseClient()
+	factory := steps.MockClientFactory(client)
+
+	manager := scaffold.NewScaffoldManagerWithRegistry(&pgRegressionRegistry{factory: factory})
+	manager.RegisterPreset(pgRegressionPreset{})
+	cfg := &config.Config{Preset: "pg-regression"}
+
+	runScaffoldPass := func(pass int) {
+		t.Helper()
+		require.NoError(t,
+			manager.RunScaffold(dir, "feature-x", "repo", "demo", "pg-regression", cfg, false, false, true),
+			"scaffold pass %d", pass)
+	}
+
+	// PASS 1: fresh dir, fresh suffix, both creates succeed on the mock.
+	runScaffoldPass(1)
+	stateAfterFirst, err := config.ReadLocalState(dir)
+	require.NoError(t, err)
+	suffix := stateAfterFirst.DbSuffix
+	require.NotEmpty(t, suffix)
+	require.Len(t, stateAfterFirst.Databases, 2)
+
+	// PASS 2: same dir and flow; the suffix loads from state and both creates
+	// hit DatabaseExistsError (the mock already holds the databases — only the
+	// PostgreSQL client produces this error in production).
+	runScaffoldPass(2)
+	stateAfterSecond, err := config.ReadLocalState(dir)
+	require.NoError(t, err)
+
+	assert.Equal(t, suffix, stateAfterSecond.DbSuffix, "re-scaffold must not rotate the persisted suffix")
+	require.Len(t, stateAfterSecond.Databases, 2, "re-scaffold must not accumulate ownership records")
+	assert.Equal(t, stateAfterFirst.Databases, stateAfterSecond.Databases, "record names must be unchanged")
+
+	var appRecord, testRecord config.OwnedDatabase
+	roleCounts := make(map[string]int)
+	for _, record := range stateAfterSecond.Databases {
+		roleCounts[record.Role]++
+		switch record.Role {
+		case config.DbRoleApplication:
+			appRecord = record
+		case config.DbRoleTesting:
+			testRecord = record
+		}
+	}
+	assert.Equal(t, map[string]int{config.DbRoleApplication: 1, config.DbRoleTesting: 1}, roleCounts)
+
+	// No rotation anywhere: pass 2 retried the exact pass-1 names.
+	assert.Equal(t,
+		[]string{appRecord.Name, testRecord.Name, appRecord.Name, testRecord.Name},
+		client.GetCreateCalls())
+
+	// exec is not bricked after the re-scaffold.
+	appDb, testDb, err := resolveExecDatabases(dir)
+	require.NoError(t, err)
+	assert.Equal(t, appRecord.Name, appDb)
+	assert.Equal(t, testRecord.Name, testDb)
+
+	// Cleanup selection stays correct: exact records plus scripted worker
+	// families enumerate with zero drops under dry-run.
+	client.SetListResultsForPattern(
+		steps.EscapeLikePattern(appRecord.Name)+`\_test\_%`,
+		[]string{appRecord.Name + "_test_1", appRecord.Name + "_test_2"},
+	)
+	output := &bytes.Buffer{}
+	destroyStep := steps.NewDbDestroyStepWithFactoryAndWriter(
+		config.StepConfig{Name: config.StepDbDestroy}, factory, output)
+	ctx := &types.ScaffoldContext{WorktreePath: dir}
+	require.NoError(t, destroyStep.Run(ctx, types.StepOptions{DryRun: true, Quiet: true}))
+
+	expected := fmt.Sprintf(
+		"Would drop database: %s\nWould drop database: %s\nWould drop database: %s\nWould drop database: %s\n",
+		appRecord.Name, testRecord.Name, appRecord.Name+"_test_1", appRecord.Name+"_test_2")
+	assert.Equal(t, expected, output.String())
+	assert.Empty(t, client.GetDropCalls(), "dry-run selection must never drop")
+}

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -20,6 +20,7 @@ var skipFirstRunCommands = map[string]bool{
 	"__completeNoDesc": true,
 	"version":          true,
 	"help":             true,
+	"exec":             true,
 }
 
 // shouldRunSetupWizard returns true when the setup wizard should be triggered.
@@ -190,6 +191,7 @@ Commands:
   remove       Remove a worktree
   prune        Remove merged worktrees
   scaffold     Run scaffold steps for a worktree
+  exec         Run a command with the worktree test database
   pull-config  Copy anvil.yaml from default branch worktree
   repair       Repair git configuration for existing project
   install      Setup global configuration

--- a/internal/cli/root_test.go
+++ b/internal/cli/root_test.go
@@ -1,0 +1,51 @@
+package cli
+
+import (
+	"bytes"
+	"io"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSkipFirstRunCommands_IncludesExec(t *testing.T) {
+	assert.True(t, skipFirstRunCommands["exec"], "exec must never trigger the first-run wizard")
+}
+
+func TestPrintBanner_ListsExec(t *testing.T) {
+	oldStdout := os.Stdout
+	reader, writer, err := os.Pipe()
+	require.NoError(t, err)
+	os.Stdout = writer
+	printBanner()
+	os.Stdout = oldStdout
+	require.NoError(t, writer.Close())
+
+	var buf bytes.Buffer
+	_, err = io.Copy(&buf, reader)
+	require.NoError(t, err)
+	require.NoError(t, reader.Close())
+
+	assert.Contains(t, buf.String(), "exec")
+}
+
+func TestCompletion_IncludesExec(t *testing.T) {
+	// Cobra's generated shell scripts resolve command names dynamically through
+	// the hidden __complete command, so that is the surface completion uses.
+	buf := new(bytes.Buffer)
+	rootCmd.SetOut(buf)
+	rootCmd.SetErr(buf)
+	rootCmd.SetArgs([]string{cobra.ShellCompNoDescRequestCmd, ""})
+	t.Cleanup(func() {
+		rootCmd.SetOut(nil)
+		rootCmd.SetErr(nil)
+		rootCmd.SetArgs(nil)
+	})
+
+	require.NoError(t, rootCmd.Execute())
+	assert.Contains(t, strings.Split(buf.String(), "\n"), "exec")
+}

--- a/internal/cli/scaffold_test.go
+++ b/internal/cli/scaffold_test.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"os"
 	"os/exec"
 	"path/filepath"
 	"testing"
@@ -12,9 +13,9 @@ import (
 func getAnvilBinary(t *testing.T) string {
 	t.Helper()
 
-	binary := "/tmp/anvil"
-	if _, err := exec.LookPath(binary); err != nil {
-		t.Skip("anvil binary not found at /tmp/anvil - build with: go build -o /tmp/anvil ./cmd/anvil")
+	binary := os.Getenv("ANVIL_TEST_BIN")
+	if binary == "" {
+		t.Fatal("ANVIL_TEST_BIN is not set; TestMain must build the anvil test binary before tests run")
 	}
 	return binary
 }
@@ -37,7 +38,7 @@ func TestScaffoldHelp(t *testing.T) {
 	output, err := anvilCmd.CombinedOutput()
 	assert.NoError(t, err)
 	assert.Contains(t, string(output), "Run scaffold steps for an existing worktree")
-	assert.Contains(t, string(output), "[PATH]")
+	assert.Contains(t, string(output), "[WORKTREE]")
 }
 
 func TestScaffoldInvalidWorktree(t *testing.T) {

--- a/internal/cli/workflow_security_test.go
+++ b/internal/cli/workflow_security_test.go
@@ -1,0 +1,65 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+)
+
+type workflowDefinition struct {
+	Jobs map[string]workflowJob `yaml:"jobs"`
+}
+
+type workflowJob struct {
+	Steps []workflowStep `yaml:"steps"`
+}
+
+type workflowStep struct {
+	Name string `yaml:"name"`
+	Run  string `yaml:"run"`
+}
+
+func loadWorkflow(t *testing.T, name string) workflowDefinition {
+	t.Helper()
+	path := filepath.Join("..", "..", ".github", "workflows", name)
+	contents, err := os.ReadFile(path)
+	require.NoError(t, err)
+	var workflow workflowDefinition
+	require.NoError(t, yaml.Unmarshal(contents, &workflow))
+	return workflow
+}
+
+func workflowRunStep(t *testing.T, workflowName, stepName string) workflowStep {
+	t.Helper()
+	workflow := loadWorkflow(t, workflowName)
+	for _, job := range workflow.Jobs {
+		for _, step := range job.Steps {
+			if step.Name == stepName {
+				require.NotEmpty(t, step.Run, "%s step %q must have a run script", workflowName, stepName)
+				return step
+			}
+		}
+	}
+	t.Fatalf("%s has no step named %q", workflowName, stepName)
+	return workflowStep{}
+}
+
+func TestWorkflowRunScriptsContainNoGitHubExpressions(t *testing.T) {
+	for _, workflowName := range []string{"release.yml", "changelog.yml"} {
+		t.Run(workflowName, func(t *testing.T) {
+			workflow := loadWorkflow(t, workflowName)
+			for jobName, job := range workflow.Jobs {
+				for _, step := range job.Steps {
+					assert.False(t, strings.Contains(step.Run, "${{"),
+						"%s job %q step %q interpolates a GitHub expression into run source:\n%s",
+						workflowName, jobName, step.Name, step.Run)
+				}
+			}
+		})
+	}
+}

--- a/internal/cli/workflow_security_unix_test.go
+++ b/internal/cli/workflow_security_unix_test.go
@@ -1,0 +1,119 @@
+//go:build !windows
+
+package cli
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func runWorkflowScript(t *testing.T, step workflowStep, dir string, env ...string) {
+	t.Helper()
+	cmd := exec.Command("sh", "-eu", "-c", step.Run)
+	cmd.Dir = dir
+	cmd.Env = subprocessEnv(t, env...)
+	output, err := cmd.CombinedOutput()
+	require.NoError(t, err, "workflow step %q failed: %s", step.Name, output)
+}
+
+func TestChangelogWorkflowGuardPreservesHostileTagData(t *testing.T) {
+	step := workflowRunStep(t, "changelog.yml", "Check for existing release heading")
+
+	for _, present := range []bool{true, false} {
+		name := "absent"
+		if present {
+			name = "present"
+		}
+		t.Run(name, func(t *testing.T) {
+			dir := t.TempDir()
+			marker := filepath.Join(dir, "injected-marker")
+			tag := "v1.8.0$(touch " + marker + ");`touch " + marker + "`'\""
+			changelog := "# Changelog\n"
+			if present {
+				changelog += "\n## [" + tag + "](https://example.invalid/compare) - 2026-07-17\n"
+			}
+			require.NoError(t, os.WriteFile(filepath.Join(dir, "CHANGELOG.md"), []byte(changelog), 0o644))
+			githubOutput := filepath.Join(dir, "github-output")
+
+			runWorkflowScript(t, step, dir,
+				"RELEASE_TAG="+tag,
+				"GITHUB_OUTPUT="+githubOutput,
+			)
+
+			output, err := os.ReadFile(githubOutput)
+			require.NoError(t, err)
+			expected := "exists=false\n"
+			if present {
+				expected = "exists=true\n"
+			}
+			assert.Equal(t, expected, string(output))
+			assert.NoFileExists(t, marker)
+		})
+	}
+}
+
+func TestReleaseWorkflowBodyPreservesHostileAnnotationExactly(t *testing.T) {
+	step := workflowRunStep(t, "release.yml", "Build release body")
+	repo := t.TempDir()
+	runGitCommand(t, repo, "init", "-b", "main")
+	require.NoError(t, os.WriteFile(filepath.Join(repo, "README.md"), []byte("fixture\n"), 0o644))
+	runGitCommand(t, repo, "add", "README.md")
+	runGitCommand(t, repo, "commit", "-m", "fixture")
+	runGitCommand(t, repo, "tag", "--no-sign", "v1.7.1")
+
+	marker := filepath.Join(repo, "injected-marker")
+	annotation := "# Release notes\n\n" +
+		"`touch " + marker + "`\n" +
+		"$(touch " + marker + ")\n" +
+		"Quotes: \"double\" and 'single'\n" +
+		"EOF\n"
+	annotationFile := filepath.Join(repo, "annotation.md")
+	require.NoError(t, os.WriteFile(annotationFile, []byte(annotation), 0o644))
+	runGitCommand(t, repo, "tag", "--no-sign", "-a", "v1.8.0", "--cleanup=verbatim", "-F", annotationFile)
+
+	direct := exec.Command("git", "cat-file", "tag", "v1.8.0")
+	direct.Dir = repo
+	tagObject, err := direct.Output()
+	require.NoError(t, err)
+	_, directAnnotation, found := bytes.Cut(tagObject, []byte("\n\n"))
+	require.True(t, found, "annotated tag object has no header separator")
+	require.Equal(t, annotation, string(directAnnotation))
+
+	runnerTemp := t.TempDir()
+	var bodyPaths []string
+	for range 2 {
+		githubOutput := filepath.Join(t.TempDir(), "github-output")
+		runWorkflowScript(t, step, repo,
+			"VERSION=1.8.0",
+			"PREVIOUS=v1.7.1",
+			"REPOSITORY=naoray/anvil",
+			"RUNNER_TEMP="+runnerTemp,
+			"GITHUB_OUTPUT="+githubOutput,
+		)
+
+		output, readErr := os.ReadFile(githubOutput)
+		require.NoError(t, readErr)
+		bodyPath, found := strings.CutPrefix(strings.TrimSuffix(string(output), "\n"), "BODY_PATH=")
+		require.True(t, found, "unexpected GITHUB_OUTPUT: %q", output)
+		assert.Equal(t, runnerTemp, filepath.Dir(bodyPath))
+		bodyPaths = append(bodyPaths, bodyPath)
+
+		body, bodyErr := os.ReadFile(bodyPath)
+		require.NoError(t, bodyErr)
+		link := fmt.Sprintf("\n\n**Full changelog:** [%s..%s](https://github.com/%s/compare/%s..%s)\n",
+			"v1.7.1", "v1.8.0", "naoray/anvil", "v1.7.1", "v1.8.0")
+		expected := append(bytes.Clone(directAnnotation), link...)
+		assert.Equal(t, expected, body)
+		assert.Contains(t, string(body), "\nEOF\n")
+		assert.NoFileExists(t, marker)
+	}
+	assert.NotEqual(t, bodyPaths[0], bodyPaths[1], "release body files must be collision-safe")
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -190,12 +190,14 @@ type StepConfig struct {
 	Source          string   `mapstructure:"source"`
 	SourceFile      string   `mapstructure:"source_file"`
 	Type            string   `mapstructure:"type"`
+	Role            string   `mapstructure:"role"`
 }
 
 // CleanupStep represents a cleanup step configuration
 type CleanupStep struct {
 	ConditionHolder `mapstructure:",squash"`
-	Name            string `mapstructure:"name"`
+	Name            string   `mapstructure:"name"`
+	Args            []string `mapstructure:"args"`
 }
 
 // CleanupConfig represents cleanup configuration
@@ -223,11 +225,12 @@ type GlobalConfig struct {
 
 // ProjectInfo represents a linked project's configuration
 type ProjectInfo struct {
-	Path          string `mapstructure:"path"`
-	DefaultBranch string `mapstructure:"default_branch"`
-	Preset        string `mapstructure:"preset"`
-	SiteName      string `mapstructure:"site_name"`
-	EditorCmd     string `mapstructure:"editor_cmd"`
+	Path          string        `mapstructure:"path"`
+	DefaultBranch string        `mapstructure:"default_branch"`
+	Preset        string        `mapstructure:"preset"`
+	SiteName      string        `mapstructure:"site_name"`
+	EditorCmd     string        `mapstructure:"editor_cmd"`
+	Cleanup       CleanupConfig `mapstructure:"cleanup"`
 }
 
 // ToolInfo represents detected tool information

--- a/internal/config/local_state.go
+++ b/internal/config/local_state.go
@@ -1,24 +1,91 @@
 package config
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
+	"regexp"
+	"strings"
 
 	"gopkg.in/yaml.v3"
 )
 
-// LocalState represents worktree-local state that should never be committed
-type LocalState struct {
-	DbSuffix string `yaml:"db_suffix"`
+const (
+	DbRoleApplication = "application"
+	DbRoleTesting     = "testing"
+)
+
+var databaseIdentifierPattern = regexp.MustCompile(`^[A-Za-z0-9_]+$`)
+
+// OwnedDatabase records a database that Anvil created for a worktree.
+type OwnedDatabase struct {
+	Name   string `yaml:"name"`
+	Engine string `yaml:"engine"`
+	Role   string `yaml:"role"`
 }
 
-// ReadLocalState reads worktree-local state from .anvil.local
+// LocalState represents worktree-local state that should never be committed.
+type LocalState struct {
+	DbSuffix  string          `yaml:"db_suffix"`
+	Databases []OwnedDatabase `yaml:"databases,omitempty"`
+}
+
+// IsValidDatabaseIdentifier reports whether a name is safe for Anvil's
+// identifier-quoted create/drop statements.
+func IsValidDatabaseIdentifier(name string) bool {
+	return databaseIdentifierPattern.MatchString(name)
+}
+
+// ValidateOwnedDatabases is the shared fail-closed gate for database ownership
+// records. It reports every record error in state order.
+func ValidateOwnedDatabases(databases []OwnedDatabase) error {
+	var validationErrors []error
+	seenEngines := make(map[string]struct{})
+	engineOrder := make([]string, 0, 2)
+
+	for index, database := range databases {
+		if !IsValidDatabaseIdentifier(database.Name) {
+			validationErrors = append(validationErrors,
+				fmt.Errorf("invalid database name %q in record %d", database.Name, index))
+		}
+
+		switch database.Role {
+		case DbRoleApplication, DbRoleTesting:
+		default:
+			validationErrors = append(validationErrors,
+				fmt.Errorf("unsupported database record role %q in record %q; supported roles: application, testing", database.Role, database.Name))
+		}
+
+		switch DatabaseEngine(database.Engine) {
+		case DBEngineMySQL, DBEnginePgSQL:
+			if _, exists := seenEngines[database.Engine]; !exists {
+				seenEngines[database.Engine] = struct{}{}
+				engineOrder = append(engineOrder, database.Engine)
+			}
+		default:
+			validationErrors = append(validationErrors,
+				fmt.Errorf("unsupported database engine %q in record %q; supported engines: mysql, pgsql", database.Engine, database.Name))
+		}
+	}
+
+	if len(engineOrder) > 1 {
+		validationErrors = append(validationErrors,
+			fmt.Errorf("database records must use exactly one supported engine; found %s", strings.Join(engineOrder, ", ")))
+	}
+
+	return errors.Join(validationErrors...)
+}
+
+// ReadLocalState reads worktree-local state from .anvil.local.
 func ReadLocalState(worktreePath string) (*LocalState, error) {
 	configPath := filepath.Join(worktreePath, LocalStateFile)
 
-	if _, err := os.Stat(configPath); os.IsNotExist(err) {
-		return &LocalState{}, nil
+	if _, err := os.Stat(configPath); err != nil {
+		if os.IsNotExist(err) {
+			return &LocalState{}, nil
+		}
+		return nil, fmt.Errorf("stating local state: %w", err)
 	}
 
 	content, err := os.ReadFile(configPath)
@@ -34,36 +101,99 @@ func ReadLocalState(worktreePath string) (*LocalState, error) {
 	return &state, nil
 }
 
-// WriteLocalState writes worktree-local state to .anvil.local
+// WriteLocalState merges worktree-local state into .anvil.local. Canonical
+// database records replace by role while unknown YAML fields are preserved.
 func WriteLocalState(worktreePath string, data LocalState) error {
 	configPath := filepath.Join(worktreePath, LocalStateFile)
 
-	// Read existing state if it exists
-	var existing map[string]any
-	if content, err := os.ReadFile(configPath); err == nil {
+	existing := make(map[string]any)
+	content, err := os.ReadFile(configPath)
+	switch {
+	case err == nil:
 		if err := yaml.Unmarshal(content, &existing); err != nil {
 			return fmt.Errorf("parsing existing local state: %w", err)
 		}
+	case os.IsNotExist(err):
+	default:
+		return fmt.Errorf("reading existing local state: %w", err)
 	}
-
 	if existing == nil {
 		existing = make(map[string]any)
 	}
 
-	// Merge new data into existing state
 	if data.DbSuffix != "" {
 		existing["db_suffix"] = data.DbSuffix
 	}
 
-	// Marshal and write
-	content, err := yaml.Marshal(existing)
+	existingDatabases, hasExistingDatabases := existing["databases"]
+	if hasExistingDatabases || len(data.Databases) > 0 {
+		merged, err := mergeOwnedDatabases(existingDatabases, data.Databases)
+		if err != nil {
+			return err
+		}
+		existing["databases"] = merged
+	}
+
+	content, err = yaml.Marshal(existing)
 	if err != nil {
 		return fmt.Errorf("marshaling local state: %w", err)
 	}
-
-	if err := os.WriteFile(configPath, content, 0644); err != nil {
+	if err := os.WriteFile(configPath, content, 0o644); err != nil {
 		return fmt.Errorf("writing local state: %w", err)
 	}
-
 	return nil
+}
+
+func mergeOwnedDatabases(existingRaw any, updates []OwnedDatabase) ([]any, error) {
+	var records []any
+	if existingRaw != nil {
+		var ok bool
+		records, ok = existingRaw.([]any)
+		if !ok {
+			return nil, fmt.Errorf("malformed databases in local state: expected a list, got %T", existingRaw)
+		}
+	}
+
+	for index, raw := range records {
+		record, ok := raw.(map[string]any)
+		if !ok {
+			return nil, fmt.Errorf("malformed databases in local state: record %d is %T, want mapping", index, raw)
+		}
+		for _, field := range []string{"name", "engine", "role"} {
+			if value, exists := record[field]; exists {
+				if _, ok := value.(string); !ok {
+					return nil, fmt.Errorf("malformed databases in local state: record %d field %q is %T, want string", index, field, value)
+				}
+			}
+		}
+	}
+
+	for _, update := range updates {
+		updated := false
+		next := make([]any, 0, len(records)+1)
+		for _, raw := range records {
+			record := raw.(map[string]any)
+			role, _ := record["role"].(string)
+			if role != update.Role {
+				next = append(next, record)
+				continue
+			}
+			if updated {
+				continue
+			}
+			record["name"] = update.Name
+			record["engine"] = update.Engine
+			record["role"] = update.Role
+			next = append(next, record)
+			updated = true
+		}
+		if !updated {
+			next = append(next, map[string]any{
+				"name": update.Name, "engine": update.Engine, "role": update.Role,
+			})
+		}
+		records = next
+	}
+
+	return records, nil
 }

--- a/internal/config/owned_databases_test.go
+++ b/internal/config/owned_databases_test.go
@@ -1,0 +1,262 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestLocalState_OwnedDatabasesRoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	want := LocalState{
+		DbSuffix: "top_provider",
+		Databases: []OwnedDatabase{
+			{Name: "dashboard_top_provider", Engine: "mysql", Role: DbRoleApplication},
+			{Name: "dashboard_top_provider_test", Engine: "mysql", Role: DbRoleTesting},
+		},
+	}
+	if err := WriteLocalState(dir, want); err != nil {
+		t.Fatalf("WriteLocalState() error = %v", err)
+	}
+
+	got, err := ReadLocalState(dir)
+	if err != nil {
+		t.Fatalf("ReadLocalState() error = %v", err)
+	}
+	if got.DbSuffix != want.DbSuffix {
+		t.Fatalf("DbSuffix = %q, want %q", got.DbSuffix, want.DbSuffix)
+	}
+	if len(got.Databases) != len(want.Databases) {
+		t.Fatalf("Databases length = %d, want %d", len(got.Databases), len(want.Databases))
+	}
+	for i := range want.Databases {
+		if got.Databases[i] != want.Databases[i] {
+			t.Fatalf("Databases[%d] = %#v, want %#v", i, got.Databases[i], want.Databases[i])
+		}
+	}
+}
+
+func TestReadLocalState_LegacySuffixOnly(t *testing.T) {
+	dir := t.TempDir()
+	writeTestLocalState(t, dir, "db_suffix: top_provider\n")
+
+	state, err := ReadLocalState(dir)
+	if err != nil {
+		t.Fatalf("ReadLocalState() error = %v", err)
+	}
+	if state.DbSuffix != "top_provider" || len(state.Databases) != 0 {
+		t.Fatalf("legacy state = %#v", state)
+	}
+}
+
+func TestWriteLocalState_CanonicalReplaceByRole(t *testing.T) {
+	dir := t.TempDir()
+	if err := WriteLocalState(dir, LocalState{
+		DbSuffix: "top_provider",
+		Databases: []OwnedDatabase{
+			{Name: "app_old", Engine: "pgsql", Role: DbRoleApplication},
+			{Name: "app_old_test", Engine: "pgsql", Role: DbRoleTesting},
+		},
+	}); err != nil {
+		t.Fatalf("initial WriteLocalState() error = %v", err)
+	}
+	if err := WriteLocalState(dir, LocalState{Databases: []OwnedDatabase{
+		{Name: "app_new", Engine: "pgsql", Role: DbRoleApplication},
+		{Name: "app_new_test", Engine: "pgsql", Role: DbRoleTesting},
+	}}); err != nil {
+		t.Fatalf("replacement WriteLocalState() error = %v", err)
+	}
+
+	state, err := ReadLocalState(dir)
+	if err != nil {
+		t.Fatalf("ReadLocalState() error = %v", err)
+	}
+	if state.DbSuffix != "top_provider" {
+		t.Fatalf("DbSuffix = %q, want top_provider", state.DbSuffix)
+	}
+	if len(state.Databases) != 2 {
+		t.Fatalf("Databases = %#v, want two canonical records", state.Databases)
+	}
+	if state.Databases[0].Name != "app_new" || state.Databases[1].Name != "app_new_test" {
+		t.Fatalf("Databases = %#v, want replacement names", state.Databases)
+	}
+}
+
+func TestWriteLocalState_PrunesDuplicateCanonicalRoles(t *testing.T) {
+	dir := t.TempDir()
+	writeTestLocalState(t, dir, "db_suffix: top_provider\ndatabases:\n  - name: first_test\n    engine: mysql\n    role: testing\n  - name: stale_test\n    engine: mysql\n    role: testing\n")
+
+	if err := WriteLocalState(dir, LocalState{Databases: []OwnedDatabase{{
+		Name: "canonical_test", Engine: "mysql", Role: DbRoleTesting,
+	}}}); err != nil {
+		t.Fatalf("WriteLocalState() error = %v", err)
+	}
+	state, err := ReadLocalState(dir)
+	if err != nil {
+		t.Fatalf("ReadLocalState() error = %v", err)
+	}
+	if len(state.Databases) != 1 || state.Databases[0].Name != "canonical_test" {
+		t.Fatalf("Databases = %#v, want one canonical testing record", state.Databases)
+	}
+}
+
+func TestWriteLocalState_PreservesUnknownFields(t *testing.T) {
+	dir := t.TempDir()
+	seed := "db_suffix: top_provider\ncustom_top: keep\ndatabases:\n  - name: app_old\n    engine: pgsql\n    role: application\n    custom_rec: keep-too\n  - name: weird\n    engine: pgsql\n    role: someday-role\n"
+	writeTestLocalState(t, dir, seed)
+
+	if err := WriteLocalState(dir, LocalState{Databases: []OwnedDatabase{{
+		Name: "app_new", Engine: "pgsql", Role: DbRoleApplication,
+	}}}); err != nil {
+		t.Fatalf("WriteLocalState() error = %v", err)
+	}
+	raw, err := os.ReadFile(filepath.Join(dir, LocalStateFile))
+	if err != nil {
+		t.Fatalf("ReadFile() error = %v", err)
+	}
+	for _, want := range []string{"custom_top: keep", "custom_rec: keep-too", "someday-role", "app_new"} {
+		if !strings.Contains(string(raw), want) {
+			t.Fatalf("rewritten state missing %q:\n%s", want, raw)
+		}
+	}
+	if strings.Contains(string(raw), "app_old") {
+		t.Fatalf("rewritten state retained replaced name:\n%s", raw)
+	}
+}
+
+func TestWriteLocalState_MalformedDatabasesIsHardError(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, LocalStateFile)
+	before := []byte("db_suffix: top_provider\ndatabases: not-a-list\n")
+	if err := os.WriteFile(path, before, 0o644); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+
+	err := WriteLocalState(dir, LocalState{Databases: []OwnedDatabase{{
+		Name: "app_new", Engine: "mysql", Role: DbRoleApplication,
+	}}})
+	if err == nil {
+		t.Fatal("WriteLocalState() error = nil, want malformed databases error")
+	}
+	after, readErr := os.ReadFile(path)
+	if readErr != nil {
+		t.Fatalf("ReadFile() error = %v", readErr)
+	}
+	if string(after) != string(before) {
+		t.Fatalf("malformed file changed:\nbefore=%q\nafter=%q", before, after)
+	}
+}
+
+func TestIsValidDatabaseIdentifier(t *testing.T) {
+	for _, valid := range []string{"a", "a_B9", "DATABASE_123"} {
+		if !IsValidDatabaseIdentifier(valid) {
+			t.Errorf("IsValidDatabaseIdentifier(%q) = false, want true", valid)
+		}
+	}
+	for _, invalid := range []string{"", "a-b", "a;drop", "a b", "a%b"} {
+		if IsValidDatabaseIdentifier(invalid) {
+			t.Errorf("IsValidDatabaseIdentifier(%q) = true, want false", invalid)
+		}
+	}
+}
+
+func TestValidateOwnedDatabases_ValidSingleEngine(t *testing.T) {
+	err := ValidateOwnedDatabases([]OwnedDatabase{
+		{Name: "app", Engine: "mysql", Role: DbRoleApplication},
+		{Name: "app_test", Engine: "mysql", Role: DbRoleTesting},
+	})
+	if err != nil {
+		t.Fatalf("ValidateOwnedDatabases() error = %v", err)
+	}
+}
+
+func TestValidateOwnedDatabases_RejectsUnsafeRecords(t *testing.T) {
+	tests := []struct {
+		name string
+		dbs  []OwnedDatabase
+		want string
+	}{
+		{"unknown role", []OwnedDatabase{{Name: "app", Engine: "mysql", Role: "someday-role"}}, "unsupported database record role"},
+		{"unknown engine", []OwnedDatabase{{Name: "app", Engine: "oracle", Role: DbRoleApplication}}, "unsupported database engine"},
+		{"sqlite engine", []OwnedDatabase{{Name: "app", Engine: "sqlite", Role: DbRoleApplication}}, "unsupported database engine"},
+		{"mixed supported engines", []OwnedDatabase{
+			{Name: "app", Engine: "mysql", Role: DbRoleApplication},
+			{Name: "app_test", Engine: "pgsql", Role: DbRoleTesting},
+		}, "exactly one supported engine"},
+		{"invalid name", []OwnedDatabase{{Name: "bad;drop", Engine: "mysql", Role: DbRoleApplication}}, "invalid database name"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateOwnedDatabases(tt.dbs)
+			if err == nil || !strings.Contains(err.Error(), tt.want) {
+				t.Fatalf("ValidateOwnedDatabases() error = %v, want substring %q", err, tt.want)
+			}
+		})
+	}
+}
+
+func TestValidateOwnedDatabases_AggregatesInStateOrder(t *testing.T) {
+	err := ValidateOwnedDatabases([]OwnedDatabase{
+		{Name: "bad;first", Engine: "mysql", Role: "someday-role"},
+		{Name: "valid_second", Engine: "oracle", Role: DbRoleTesting},
+		{Name: "valid_third", Engine: "pgsql", Role: DbRoleApplication},
+	})
+	if err == nil {
+		t.Fatal("ValidateOwnedDatabases() error = nil")
+	}
+	message := err.Error()
+	for _, want := range []string{"someday-role", "oracle"} {
+		if !strings.Contains(message, want) {
+			t.Fatalf("aggregate missing %q: %s", want, message)
+		}
+	}
+	wants := []string{"bad;first", "valid_second", "exactly one supported engine"}
+	last := -1
+	for _, want := range wants {
+		idx := strings.Index(message, want)
+		if idx < 0 {
+			t.Fatalf("aggregate missing %q: %s", want, message)
+		}
+		if idx < last {
+			t.Fatalf("aggregate order is not deterministic for %q: %s", want, message)
+		}
+		last = idx
+	}
+}
+
+func TestDbCreateConfig_RoleValidation(t *testing.T) {
+	for _, role := range []string{"", DbRoleApplication, DbRoleTesting} {
+		if err := ValidateStepConfig(StepDbCreate, StepConfig{Role: role}); err != nil {
+			t.Errorf("role %q rejected: %v", role, err)
+		}
+	}
+	if err := ValidateStepConfig(StepDbCreate, StepConfig{Role: "staging"}); err == nil || !strings.Contains(err.Error(), "invalid role") {
+		t.Fatalf("invalid role error = %v", err)
+	}
+}
+
+func TestLoadProject_DbCreateTestingRole(t *testing.T) {
+	dir := t.TempDir()
+	content := "scaffold:\n  steps:\n    - name: db.create\n      role: testing\n"
+	if err := os.WriteFile(filepath.Join(dir, ProjectConfigFile), []byte(content), 0o644); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+	cfg, err := LoadProject(dir)
+	if err != nil {
+		t.Fatalf("LoadProject() error = %v", err)
+	}
+	if len(cfg.Scaffold.Steps) != 1 || cfg.Scaffold.Steps[0].Role != DbRoleTesting {
+		t.Fatalf("loaded steps = %#v", cfg.Scaffold.Steps)
+	}
+	if err := ValidateStepConfig(cfg.Scaffold.Steps[0].Name, cfg.Scaffold.Steps[0]); err != nil {
+		t.Fatalf("loaded testing step failed validation: %v", err)
+	}
+}
+
+func writeTestLocalState(t *testing.T, dir, content string) {
+	t.Helper()
+	if err := os.WriteFile(filepath.Join(dir, LocalStateFile), []byte(content), 0o644); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+}

--- a/internal/config/step_configs.go
+++ b/internal/config/step_configs.go
@@ -139,12 +139,18 @@ type DbCreateConfig struct {
 	BaseStepConfig
 	Args []string `mapstructure:"args"`
 	Type string   `mapstructure:"type"`
+	Role string   `mapstructure:"role"`
 }
 
 // Validate checks that the db.create step config is valid.
 // All fields are optional for db.create.
 func (c DbCreateConfig) Validate() error {
-	return nil
+	switch c.Role {
+	case "", DbRoleApplication, DbRoleTesting:
+		return nil
+	default:
+		return fmt.Errorf("db.create: invalid role %q (supported roles: application, testing)", c.Role)
+	}
 }
 
 // DbDestroyConfig represents configuration for db.destroy step
@@ -217,6 +223,7 @@ func ValidateStepConfig(stepName string, cfg StepConfig) error {
 			BaseStepConfig: base,
 			Args:           cfg.Args,
 			Type:           cfg.Type,
+			Role:           cfg.Role,
 		}.Validate()
 	case StepDbDestroy:
 		return DbDestroyConfig{

--- a/internal/presets/laravel.go
+++ b/internal/presets/laravel.go
@@ -24,6 +24,7 @@ func NewLaravel() *Laravel {
 				{Name: config.StepEnvWrite, Key: "APP_KEY", Value: "{{ .AppKey }}", ConditionHolder: config.ConditionHolder{Condition: map[string]any{"env_file_missing": "APP_KEY"}}},
 				{Name: config.StepDbCreate, ConditionHolder: config.ConditionHolder{Condition: map[string]any{"env_file_contains": map[string]any{"file": ".env", "key": "DB_CONNECTION"}}}},
 				{Name: config.StepEnvWrite, Key: "DB_DATABASE", Value: "{{ .DatabaseName }}", ConditionHolder: config.ConditionHolder{Condition: map[string]any{"env_file_contains": map[string]any{"file": ".env", "key": "DB_CONNECTION"}}}},
+				{Name: "php", Args: []string{"vendor/bin/phpstan", "clear-result-cache"}, ConditionHolder: config.ConditionHolder{Condition: map[string]any{"file_exists": "vendor/bin/phpstan"}}},
 				{Name: "node.npm", Args: []string{"ci"}, ConditionHolder: config.ConditionHolder{Condition: map[string]any{"file_exists": "package-lock.json"}}},
 				{Name: "php.laravel", Args: []string{"migrate:fresh", "--seed", "--no-interaction"}},
 				{Name: "node.npm", Args: []string{"run", "build"}, ConditionHolder: config.ConditionHolder{Condition: map[string]any{"file_exists": "package-lock.json"}}},

--- a/internal/presets/laravel.go
+++ b/internal/presets/laravel.go
@@ -25,6 +25,7 @@ func NewLaravel() *Laravel {
 				{Name: config.StepDbCreate, ConditionHolder: config.ConditionHolder{Condition: map[string]any{"env_file_contains": map[string]any{"file": ".env", "key": "DB_CONNECTION"}}}},
 				{Name: config.StepEnvWrite, Key: "DB_DATABASE", Value: "{{ .DatabaseName }}", ConditionHolder: config.ConditionHolder{Condition: map[string]any{"env_file_contains": map[string]any{"file": ".env", "key": "DB_CONNECTION"}}}},
 				{Name: "php", Args: []string{"vendor/bin/phpstan", "clear-result-cache"}, ConditionHolder: config.ConditionHolder{Condition: map[string]any{"file_exists": "vendor/bin/phpstan"}}},
+				{Name: config.StepDbCreate, Role: config.DbRoleTesting, ConditionHolder: config.ConditionHolder{Condition: map[string]any{"env_file_contains": map[string]any{"file": ".env", "key": "DB_CONNECTION"}}}},
 				{Name: "node.npm", Args: []string{"ci"}, ConditionHolder: config.ConditionHolder{Condition: map[string]any{"file_exists": "package-lock.json"}}},
 				{Name: "php.laravel", Args: []string{"migrate:fresh", "--seed", "--no-interaction"}},
 				{Name: "node.npm", Args: []string{"run", "build"}, ConditionHolder: config.ConditionHolder{Condition: map[string]any{"file_exists": "package-lock.json"}}},

--- a/internal/presets/presets_test.go
+++ b/internal/presets/presets_test.go
@@ -68,7 +68,7 @@ func TestLaravelPreset_DefaultSteps(t *testing.T) {
 	preset := NewLaravel()
 	steps := preset.DefaultSteps()
 
-	require.Len(t, steps, 13)
+	require.Len(t, steps, 14)
 
 	assert.Equal(t, "php.composer", steps[0].Name)
 	assert.Equal(t, []string{"install"}, steps[0].Args)
@@ -100,24 +100,28 @@ func TestLaravelPreset_DefaultSteps(t *testing.T) {
 	assert.Equal(t, []string{"vendor/bin/phpstan", "clear-result-cache"}, steps[7].Args)
 	assert.Equal(t, "vendor/bin/phpstan", steps[7].Condition["file_exists"])
 
-	assert.Equal(t, "node.npm", steps[8].Name)
-	assert.Equal(t, []string{"ci"}, steps[8].Args)
-	assert.NotNil(t, steps[8].Condition, "npm ci should have a condition")
-	assert.Equal(t, "package-lock.json", steps[8].Condition["file_exists"])
+	assert.Equal(t, "db.create", steps[8].Name)
+	assert.Equal(t, config.DbRoleTesting, steps[8].Role)
+	assert.NotNil(t, steps[8].Condition)
 
-	assert.Equal(t, "php.laravel", steps[9].Name)
-	assert.Equal(t, []string{"migrate:fresh", "--seed", "--no-interaction"}, steps[9].Args)
+	assert.Equal(t, "node.npm", steps[9].Name)
+	assert.Equal(t, []string{"ci"}, steps[9].Args)
+	assert.NotNil(t, steps[9].Condition, "npm ci should have a condition")
+	assert.Equal(t, "package-lock.json", steps[9].Condition["file_exists"])
 
-	assert.Equal(t, "node.npm", steps[10].Name)
-	assert.Equal(t, []string{"run", "build"}, steps[10].Args)
-	assert.NotNil(t, steps[10].Condition, "npm run build should have a condition")
-	assert.Equal(t, "package-lock.json", steps[10].Condition["file_exists"])
+	assert.Equal(t, "php.laravel", steps[10].Name)
+	assert.Equal(t, []string{"migrate:fresh", "--seed", "--no-interaction"}, steps[10].Args)
 
-	assert.Equal(t, "php.laravel", steps[11].Name)
-	assert.Equal(t, []string{"storage:link", "--no-interaction"}, steps[11].Args)
+	assert.Equal(t, "node.npm", steps[11].Name)
+	assert.Equal(t, []string{"run", "build"}, steps[11].Args)
+	assert.NotNil(t, steps[11].Condition, "npm run build should have a condition")
+	assert.Equal(t, "package-lock.json", steps[11].Condition["file_exists"])
 
-	assert.Equal(t, "herd", steps[12].Name)
-	assert.Equal(t, []string{"link", "--secure", "{{ .SiteName }}"}, steps[12].Args)
+	assert.Equal(t, "php.laravel", steps[12].Name)
+	assert.Equal(t, []string{"storage:link", "--no-interaction"}, steps[12].Args)
+
+	assert.Equal(t, "herd", steps[13].Name)
+	assert.Equal(t, []string{"link", "--secure", "{{ .SiteName }}"}, steps[13].Args)
 }
 
 func TestLaravelPreset_PHPStanCacheStepIsNoOpWithoutBinary(t *testing.T) {
@@ -229,6 +233,18 @@ func TestLaravelPreset_CleanupSteps(t *testing.T) {
 	assert.Len(t, steps, 2)
 	assert.Equal(t, "herd", steps[0].Name)
 	assert.Equal(t, "db.destroy", steps[1].Name)
+}
+
+func TestLaravelSharedDBPreset_HasNoDatabaseSteps(t *testing.T) {
+	preset := NewLaravelSharedDB()
+	for _, step := range preset.DefaultSteps() {
+		assert.NotEqual(t, config.StepDbCreate, step.Name)
+		assert.NotEqual(t, config.StepDbDestroy, step.Name)
+	}
+	for _, step := range preset.CleanupSteps() {
+		assert.NotEqual(t, config.StepDbCreate, step.Name)
+		assert.NotEqual(t, config.StepDbDestroy, step.Name)
+	}
 }
 
 func TestPHPPreset_Detect(t *testing.T) {

--- a/internal/presets/presets_test.go
+++ b/internal/presets/presets_test.go
@@ -1,12 +1,19 @@
 package presets
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/naoray/anvil/internal/config"
+	anvil_exec "github.com/naoray/anvil/internal/exec"
+	"github.com/naoray/anvil/internal/scaffold"
+	scaffoldsteps "github.com/naoray/anvil/internal/scaffold/steps"
+	"github.com/naoray/anvil/internal/scaffold/types"
 )
 
 func TestLaravelPreset_Detect(t *testing.T) {
@@ -61,7 +68,7 @@ func TestLaravelPreset_DefaultSteps(t *testing.T) {
 	preset := NewLaravel()
 	steps := preset.DefaultSteps()
 
-	assert.Len(t, steps, 12)
+	require.Len(t, steps, 13)
 
 	assert.Equal(t, "php.composer", steps[0].Name)
 	assert.Equal(t, []string{"install"}, steps[0].Args)
@@ -89,18 +96,130 @@ func TestLaravelPreset_DefaultSteps(t *testing.T) {
 	assert.Equal(t, "DB_DATABASE", steps[6].Key)
 	assert.Equal(t, "{{ .DatabaseName }}", steps[6].Value)
 
-	assert.Equal(t, "node.npm", steps[7].Name)
-	assert.Equal(t, []string{"ci"}, steps[7].Args)
-	assert.NotNil(t, steps[7].Condition, "npm ci should have a condition")
-	assert.Equal(t, "package-lock.json", steps[7].Condition["file_exists"])
+	assert.Equal(t, "php", steps[7].Name)
+	assert.Equal(t, []string{"vendor/bin/phpstan", "clear-result-cache"}, steps[7].Args)
+	assert.Equal(t, "vendor/bin/phpstan", steps[7].Condition["file_exists"])
 
-	assert.Equal(t, "php.laravel", steps[8].Name)
-	assert.Equal(t, []string{"migrate:fresh", "--seed", "--no-interaction"}, steps[8].Args)
+	assert.Equal(t, "node.npm", steps[8].Name)
+	assert.Equal(t, []string{"ci"}, steps[8].Args)
+	assert.NotNil(t, steps[8].Condition, "npm ci should have a condition")
+	assert.Equal(t, "package-lock.json", steps[8].Condition["file_exists"])
 
-	assert.Equal(t, "node.npm", steps[9].Name)
-	assert.Equal(t, []string{"run", "build"}, steps[9].Args)
-	assert.NotNil(t, steps[9].Condition, "npm run build should have a condition")
-	assert.Equal(t, "package-lock.json", steps[9].Condition["file_exists"])
+	assert.Equal(t, "php.laravel", steps[9].Name)
+	assert.Equal(t, []string{"migrate:fresh", "--seed", "--no-interaction"}, steps[9].Args)
+
+	assert.Equal(t, "node.npm", steps[10].Name)
+	assert.Equal(t, []string{"run", "build"}, steps[10].Args)
+	assert.NotNil(t, steps[10].Condition, "npm run build should have a condition")
+	assert.Equal(t, "package-lock.json", steps[10].Condition["file_exists"])
+
+	assert.Equal(t, "php.laravel", steps[11].Name)
+	assert.Equal(t, []string{"storage:link", "--no-interaction"}, steps[11].Args)
+
+	assert.Equal(t, "herd", steps[12].Name)
+	assert.Equal(t, []string{"link", "--secure", "{{ .SiteName }}"}, steps[12].Args)
+}
+
+func TestLaravelPreset_PHPStanCacheStepIsNoOpWithoutBinary(t *testing.T) {
+	tmpDir := t.TempDir()
+	cacheStepConfig := laravelPHPStanCacheStepConfig(t)
+	cacheStep, err := scaffoldsteps.Create(cacheStepConfig.Name, cacheStepConfig)
+	require.NoError(t, err)
+
+	ctx := &types.ScaffoldContext{WorktreePath: tmpDir}
+	executor := scaffold.NewStepExecutor([]types.ScaffoldStep{cacheStep}, ctx, types.StepOptions{Quiet: true})
+
+	require.NoError(t, executor.Execute())
+	require.Len(t, executor.Results(), 1)
+	assert.True(t, executor.Results()[0].Skipped, "PHPStan cache invalidation should be skipped when vendor/bin/phpstan is absent")
+}
+
+func TestLaravelPreset_DelayedScaffoldClearsPHPStanCacheAfterEnvWrites(t *testing.T) {
+	tmpDir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(tmpDir, ".env.example"), []byte("APP_KEY=\nDB_CONNECTION=sqlite\nDB_DATABASE=\n"), 0644))
+
+	phpstanPath := filepath.Join(tmpDir, "vendor", "bin", "phpstan")
+	require.NoError(t, os.MkdirAll(filepath.Dir(phpstanPath), 0755))
+	require.NoError(t, os.WriteFile(phpstanPath, nil, 0644))
+
+	ctx := &types.ScaffoldContext{WorktreePath: tmpDir}
+	ctx.SetVar("AppKey", "generated-key")
+	ctx.SetVar("DatabaseName", "feature_test")
+
+	commander := &phpstanInvocationCommander{t: t, worktreePath: tmpDir}
+	commandExecutor := anvil_exec.NewCommandExecutor(commander)
+
+	var relevantSteps []types.ScaffoldStep
+	for _, stepConfig := range NewLaravel().DefaultSteps() {
+		if stepConfig.Name == "php" {
+			relevantSteps = append(relevantSteps, scaffoldsteps.NewBinaryStepWithConditionAndExecutor(stepConfig.Name, stepConfig, "php", commandExecutor))
+			continue
+		}
+
+		if stepConfig.Name != config.StepFileCopy && stepConfig.Name != config.StepEnvWrite {
+			continue
+		}
+
+		step, err := scaffoldsteps.Create(stepConfig.Name, stepConfig)
+		require.NoError(t, err)
+		relevantSteps = append(relevantSteps, step)
+	}
+
+	_, err := os.Stat(filepath.Join(tmpDir, ".env"))
+	require.ErrorIs(t, err, os.ErrNotExist, "the delayed scaffold should start before .env exists")
+
+	executor := scaffold.NewStepExecutor(relevantSteps, ctx, types.StepOptions{Quiet: true})
+	require.NoError(t, executor.Execute())
+	require.Len(t, executor.Results(), 4)
+	assert.Equal(t, config.StepEnvWrite, executor.Results()[2].Step.Name())
+	assert.Equal(t, "php", executor.Results()[3].Step.Name())
+
+	envContent, err := os.ReadFile(filepath.Join(tmpDir, ".env"))
+	require.NoError(t, err)
+	assert.Contains(t, string(envContent), "APP_KEY=generated-key")
+	assert.Contains(t, string(envContent), "DB_DATABASE=feature_test")
+
+	require.NotNil(t, commander.call, "PHPStan cache invalidation should reach the command boundary")
+	assert.Equal(t, tmpDir, commander.call.Dir)
+	assert.Equal(t, "php", commander.call.Command)
+	assert.Equal(t, []string{"vendor/bin/phpstan", "clear-result-cache"}, commander.call.Args)
+}
+
+type phpstanInvocationCommander struct {
+	t            *testing.T
+	worktreePath string
+	call         *anvil_exec.CommandCall
+}
+
+func (c *phpstanInvocationCommander) Run(_ context.Context, dir string, command string, args ...string) ([]byte, error) {
+	c.t.Helper()
+
+	require.Equal(c.t, c.worktreePath, dir)
+	envContent, err := os.ReadFile(filepath.Join(dir, ".env"))
+	require.NoError(c.t, err)
+	require.Contains(c.t, string(envContent), "APP_KEY=generated-key")
+	require.Contains(c.t, string(envContent), "DB_DATABASE=feature_test")
+
+	c.call = &anvil_exec.CommandCall{
+		Dir:     dir,
+		Command: command,
+		Args:    append([]string(nil), args...),
+	}
+
+	return nil, nil
+}
+
+func laravelPHPStanCacheStepConfig(t *testing.T) config.StepConfig {
+	t.Helper()
+
+	for _, step := range NewLaravel().DefaultSteps() {
+		if step.Name == "php" && assert.ObjectsAreEqual([]string{"vendor/bin/phpstan", "clear-result-cache"}, step.Args) {
+			return step
+		}
+	}
+
+	t.Fatal("Laravel preset should include a PHPStan result-cache invalidation step")
+	return config.StepConfig{}
 }
 
 func TestLaravelPreset_CleanupSteps(t *testing.T) {

--- a/internal/scaffold/executor.go
+++ b/internal/scaffold/executor.go
@@ -16,10 +16,15 @@ type ExecutionResult struct {
 	Skipped bool
 }
 
+type ExecutorOptions struct {
+	DelegateDryRunToSteps bool
+}
+
 type StepExecutor struct {
 	steps        []types.ScaffoldStep
 	ctx          *types.ScaffoldContext
 	opts         types.StepOptions
+	executorOpts ExecutorOptions
 	results      []ExecutionResult
 	mu           sync.Mutex
 	completedCnt int
@@ -27,10 +32,20 @@ type StepExecutor struct {
 }
 
 func NewStepExecutor(steps []types.ScaffoldStep, ctx *types.ScaffoldContext, opts types.StepOptions) *StepExecutor {
+	return NewStepExecutorWithOptions(steps, ctx, opts, ExecutorOptions{})
+}
+
+func NewStepExecutorWithOptions(
+	steps []types.ScaffoldStep,
+	ctx *types.ScaffoldContext,
+	opts types.StepOptions,
+	executorOpts ExecutorOptions,
+) *StepExecutor {
 	return &StepExecutor{
-		steps: steps,
-		ctx:   ctx,
-		opts:  opts,
+		steps:        steps,
+		ctx:          ctx,
+		opts:         opts,
+		executorOpts: executorOpts,
 	}
 }
 
@@ -89,7 +104,7 @@ func (e *StepExecutor) Execute() error {
 			// Verbose mode: print detailed output
 			fmt.Printf("[%d/%d] Executing step: %s\n", currentStep, activeSteps, step.Name())
 
-			if e.opts.DryRun {
+			if e.opts.DryRun && !e.executorOpts.DelegateDryRunToSteps {
 				fmt.Printf("[DRY-RUN] Would execute: %s\n", step.Name())
 				e.mu.Lock()
 				e.results = append(e.results, ExecutionResult{
@@ -113,13 +128,27 @@ func (e *StepExecutor) Execute() error {
 				})
 				e.completedCnt++
 				e.mu.Unlock()
-				fmt.Printf("✓ [%d/%d] %s completed\n", currentStep, activeSteps, step.Name())
+				if !e.opts.DryRun {
+					fmt.Printf("✓ [%d/%d] %s completed\n", currentStep, activeSteps, step.Name())
+				}
 			}
 		} else if !e.opts.Quiet {
 			// Normal mode: use spinner
 			if e.opts.DryRun {
-				desc := getStepDescription(step)
-				fmt.Printf("[DRY-RUN] [%d/%d] Would execute: %s\n", currentStep, activeSteps, desc)
+				if e.executorOpts.DelegateDryRunToSteps {
+					if err := step.Run(e.ctx, e.opts); err != nil {
+						e.mu.Lock()
+						e.results = append(e.results, ExecutionResult{
+							Step:  step,
+							Error: err,
+						})
+						e.mu.Unlock()
+						return fmt.Errorf("step %s failed: %w", step.Name(), err)
+					}
+				} else {
+					desc := getStepDescription(step)
+					fmt.Printf("[DRY-RUN] [%d/%d] Would execute: %s\n", currentStep, activeSteps, desc)
+				}
 				e.mu.Lock()
 				e.results = append(e.results, ExecutionResult{
 					Step: step,
@@ -145,7 +174,7 @@ func (e *StepExecutor) Execute() error {
 			}
 		} else {
 			// Quiet mode: silent execution
-			if !e.opts.DryRun {
+			if !e.opts.DryRun || e.executorOpts.DelegateDryRunToSteps {
 				if err := step.Run(e.ctx, e.opts); err != nil {
 					e.mu.Lock()
 					e.results = append(e.results, ExecutionResult{

--- a/internal/scaffold/executor_test.go
+++ b/internal/scaffold/executor_test.go
@@ -13,6 +13,7 @@ type mockStep struct {
 	conditionResult bool
 	runError        error
 	runCalled       bool
+	runOptions      []types.StepOptions
 }
 
 func (s *mockStep) Name() string {
@@ -21,6 +22,7 @@ func (s *mockStep) Name() string {
 
 func (s *mockStep) Run(ctx *types.ScaffoldContext, opts types.StepOptions) error {
 	s.runCalled = true
+	s.runOptions = append(s.runOptions, opts)
 	return s.runError
 }
 
@@ -90,7 +92,7 @@ func TestStepExecutor_Execute_StepFails(t *testing.T) {
 	assert.Contains(t, err.Error(), "step2 failed")
 }
 
-func TestStepExecutor_Execute_DryRun(t *testing.T) {
+func TestStepExecutor_DryRunDefault_DoesNotInvokeStepRun(t *testing.T) {
 	ctx := &types.ScaffoldContext{
 		WorktreePath: "/tmp",
 		Branch:       "test",
@@ -107,6 +109,30 @@ func TestStepExecutor_Execute_DryRun(t *testing.T) {
 
 	assert.NoError(t, err)
 	assert.False(t, step1.runCalled)
+	assert.Empty(t, step1.runOptions)
+}
+
+func TestStepExecutor_DelegateDryRun_InvokesRunWithDryRunTrue(t *testing.T) {
+	ctx := &types.ScaffoldContext{
+		WorktreePath: "/tmp",
+		Branch:       "test",
+	}
+	step := &mockStep{name: "step1", conditionResult: true}
+
+	executor := NewStepExecutorWithOptions(
+		[]types.ScaffoldStep{step},
+		ctx,
+		types.StepOptions{DryRun: true, Quiet: true},
+		ExecutorOptions{DelegateDryRunToSteps: true},
+	)
+
+	err := executor.Execute()
+
+	assert.NoError(t, err)
+	assert.True(t, step.runCalled)
+	if assert.Len(t, step.runOptions, 1) {
+		assert.True(t, step.runOptions[0].DryRun)
+	}
 }
 
 func TestStepExecutor_Results(t *testing.T) {

--- a/internal/scaffold/integration_test.go
+++ b/internal/scaffold/integration_test.go
@@ -179,13 +179,35 @@ APP_NAME=myapp
 			WorktreePath: tmpDir,
 		}
 
-		destroyStep, err := steps.Create("db.destroy", config.StepConfig{})
-		require.NoError(t, err)
+		mockClient := steps.NewMockDatabaseClient()
+		mockClient.AddDatabase("myapp_swift_runner")
+		mockClient.AddDatabase("myapp_swiftXrunner")
+		var factoryEngines []string
+		var factoryOptions []steps.DatabaseOptions
+
+		destroyStep := steps.NewDbDestroyStepWithFactory(config.StepConfig{
+			Type: "mysql",
+			Args: []string{"--host", "hermetic.invalid", "--port", "invalid"},
+		}, func(engine string, options steps.DatabaseOptions) (steps.DatabaseClient, error) {
+			factoryEngines = append(factoryEngines, engine)
+			factoryOptions = append(factoryOptions, options)
+			return mockClient, nil
+		})
 		err = destroyStep.Run(ctx, types.StepOptions{Verbose: false})
 		require.NoError(t, err)
 
 		suffix := ctx.GetDbSuffix()
 		assert.Equal(t, "swift_runner", suffix, "DbSuffix should be read from local state")
+		assert.Equal(t, []string{"mysql"}, factoryEngines)
+		assert.Equal(t, []steps.DatabaseOptions{{
+			Host:     "hermetic.invalid",
+			Port:     "invalid",
+			Username: "root",
+		}}, factoryOptions)
+		assert.Equal(t, []string{`%\_swift\_runner`}, mockClient.GetListCalls())
+		assert.Equal(t, []string{"myapp_swift_runner"}, mockClient.GetDropCalls())
+		assert.False(t, mockClient.HasDatabase("myapp_swift_runner"))
+		assert.True(t, mockClient.HasDatabase("myapp_swiftXrunner"))
 	})
 }
 

--- a/internal/scaffold/manager.go
+++ b/internal/scaffold/manager.go
@@ -21,6 +21,13 @@ type ScaffoldManager struct {
 	registry    StepRegistry
 }
 
+type CleanupOptions struct {
+	DryRun              bool
+	Verbose             bool
+	Quiet               bool
+	SkipDatabaseCleanup bool
+}
+
 // StepRegistry defines the interface for step creation.
 // This abstraction allows for dependency injection and testing.
 type StepRegistry interface {
@@ -154,9 +161,9 @@ func (m *ScaffoldManager) GetCleanupSteps(cfg *config.Config, worktreePath, bran
 func (m *ScaffoldManager) cleanupConfigToStepConfig(cleanupConfig config.CleanupStep) config.StepConfig {
 	stepConfig := config.StepConfig{
 		Name: cleanupConfig.Name,
-		Args: nil,
+		Args: append([]string(nil), cleanupConfig.Args...),
 	}
-	if cleanupConfig.Name == "herd" {
+	if cleanupConfig.Name == "herd" && len(stepConfig.Args) == 0 {
 		stepConfig.Args = []string{"unlink"}
 	}
 	for k, v := range cleanupConfig.Condition {
@@ -198,29 +205,8 @@ func (m *ScaffoldManager) RunScaffold(worktreePath, branch, repoName, siteName, 
 		}
 	}
 
-	// Migrate db_suffix from anvil.yaml to .anvil.local if present
-	if !dryRun {
-		if _, err := config.MigrateDbSuffixToLocal(worktreePath); err != nil {
-			return fmt.Errorf("migrating db_suffix: %w", err)
-		}
-	}
-
-	// Load local state instead of worktree config
-	localState, err := config.ReadLocalState(worktreePath)
-	if err != nil {
-		return fmt.Errorf("reading local state: %w", err)
-	}
-
-	if localState.DbSuffix == "" {
-		newSuffix := words.GenerateSuffix()
-		ctx.SetDbSuffix(newSuffix)
-		if !dryRun {
-			if err := config.WriteLocalState(worktreePath, config.LocalState{DbSuffix: newSuffix}); err != nil {
-				return fmt.Errorf("writing db_suffix to local state: %w", err)
-			}
-		}
-	} else {
-		ctx.SetDbSuffix(localState.DbSuffix)
+	if err := prepareDbSuffix(&ctx, worktreePath, dryRun); err != nil {
+		return err
 	}
 
 	stepsList, err := m.GetStepsForWorktree(cfg, worktreePath, branch)
@@ -238,17 +224,75 @@ func (m *ScaffoldManager) RunScaffold(worktreePath, branch, repoName, siteName, 
 	return nil
 }
 
+func prepareDbSuffix(ctx *types.ScaffoldContext, worktreePath string, dryRun bool) error {
+	if !dryRun {
+		if _, err := config.MigrateDbSuffixToLocal(worktreePath); err != nil {
+			return fmt.Errorf("migrating db_suffix: %w", err)
+		}
+	}
+
+	localState, err := config.ReadLocalState(worktreePath)
+	if err != nil {
+		return fmt.Errorf("reading local state: %w", err)
+	}
+	if localState.DbSuffix != "" {
+		ctx.SetDbSuffix(localState.DbSuffix)
+		ctx.SetDbSuffixLoadedFromState()
+		return nil
+	}
+
+	newSuffix := words.GenerateSuffix()
+	ctx.SetDbSuffix(newSuffix)
+	if dryRun {
+		return nil
+	}
+	if err := config.WriteLocalState(worktreePath, config.LocalState{DbSuffix: newSuffix}); err != nil {
+		return fmt.Errorf("writing db_suffix to local state: %w", err)
+	}
+	return nil
+}
+
 func (m *ScaffoldManager) RunCleanup(worktreePath, branch, repoName, siteName, preset string, cfg *config.Config, dryRun, verbose, quiet bool) error {
+	return m.RunCleanupWithOptions(
+		worktreePath,
+		branch,
+		repoName,
+		siteName,
+		preset,
+		cfg,
+		CleanupOptions{DryRun: dryRun, Verbose: verbose, Quiet: quiet},
+	)
+}
+
+func (m *ScaffoldManager) RunCleanupWithOptions(
+	worktreePath, branch, repoName, siteName, preset string,
+	cfg *config.Config,
+	cleanupOpts CleanupOptions,
+) error {
 	ctx := m.newScaffoldContext(worktreePath, branch, repoName, siteName, preset)
 
 	stepsList, err := m.GetCleanupSteps(cfg, worktreePath, branch)
 	if err != nil {
 		return fmt.Errorf("getting cleanup steps: %w", err)
 	}
+	if cleanupOpts.SkipDatabaseCleanup {
+		filtered := make([]types.ScaffoldStep, 0, len(stepsList))
+		for _, step := range stepsList {
+			if step.Name() != config.StepDbDestroy {
+				filtered = append(filtered, step)
+			}
+		}
+		stepsList = filtered
+	}
 
-	opts := m.stepOptionsFromFlags(dryRun, verbose, quiet)
+	opts := m.stepOptionsFromFlags(cleanupOpts.DryRun, cleanupOpts.Verbose, cleanupOpts.Quiet)
 
-	executor := NewStepExecutor(stepsList, &ctx, opts)
+	executor := NewStepExecutorWithOptions(
+		stepsList,
+		&ctx,
+		opts,
+		ExecutorOptions{DelegateDryRunToSteps: true},
+	)
 	if err := executor.Execute(); err != nil {
 		return err
 	}

--- a/internal/scaffold/manager_test.go
+++ b/internal/scaffold/manager_test.go
@@ -1,0 +1,139 @@
+package scaffold
+
+import (
+	"slices"
+	"testing"
+
+	"github.com/naoray/anvil/internal/config"
+	"github.com/naoray/anvil/internal/scaffold/types"
+)
+
+func TestCleanupConfigToStepConfig_PreservesArgsAndHerdDefault(t *testing.T) {
+	manager := &ScaffoldManager{}
+
+	databaseArgs := []string{"--host=127.0.0.1", "--port=15432"}
+	database := manager.cleanupConfigToStepConfig(config.CleanupStep{
+		Name: config.StepDbDestroy,
+		Args: databaseArgs,
+	})
+	if !slices.Equal(database.Args, databaseArgs) {
+		t.Fatalf("db.destroy args = %v, want %v", database.Args, databaseArgs)
+	}
+
+	herd := manager.cleanupConfigToStepConfig(config.CleanupStep{Name: "herd"})
+	if !slices.Equal(herd.Args, []string{"unlink"}) {
+		t.Fatalf("default herd args = %v, want [unlink]", herd.Args)
+	}
+
+	herdOverride := manager.cleanupConfigToStepConfig(config.CleanupStep{
+		Name: "herd",
+		Args: []string{"unlink", "custom.test"},
+	})
+	if !slices.Equal(herdOverride.Args, []string{"unlink", "custom.test"}) {
+		t.Fatalf("explicit herd args = %v", herdOverride.Args)
+	}
+}
+
+type cleanupRecordingRegistry struct {
+	steps map[string]*mockStep
+}
+
+func (r *cleanupRecordingRegistry) Create(name string, _ config.StepConfig) (types.ScaffoldStep, error) {
+	return r.steps[name], nil
+}
+
+func (r *cleanupRecordingRegistry) ListRegistered() []string {
+	return nil
+}
+
+type cleanupRecordingPreset struct {
+	cleanup []config.CleanupStep
+}
+
+func (p cleanupRecordingPreset) Name() string                       { return "recording" }
+func (p cleanupRecordingPreset) Detect(string) bool                 { return false }
+func (p cleanupRecordingPreset) DefaultSteps() []config.StepConfig  { return nil }
+func (p cleanupRecordingPreset) CleanupSteps() []config.CleanupStep { return p.cleanup }
+
+func TestRunCleanupWithOptions_SkipDatabaseCleanup(t *testing.T) {
+	herdStep := &mockStep{name: "herd", conditionResult: true}
+	databaseStep := &mockStep{name: config.StepDbDestroy, conditionResult: true}
+	registry := &cleanupRecordingRegistry{steps: map[string]*mockStep{
+		"herd":               herdStep,
+		config.StepDbDestroy: databaseStep,
+	}}
+	manager := NewScaffoldManagerWithRegistry(registry)
+	manager.RegisterPreset(cleanupRecordingPreset{cleanup: []config.CleanupStep{
+		{Name: "herd"},
+		{Name: config.StepDbDestroy},
+	}})
+	cfg := &config.Config{Preset: "recording"}
+
+	err := manager.RunCleanupWithOptions(
+		t.TempDir(), "branch", "repo", "site", "recording", cfg,
+		CleanupOptions{Quiet: true, SkipDatabaseCleanup: true},
+	)
+
+	if err != nil {
+		t.Fatalf("RunCleanupWithOptions() error = %v", err)
+	}
+	if !herdStep.runCalled || databaseStep.runCalled {
+		t.Fatalf("cleanup calls: herd=%v db.destroy=%v", herdStep.runCalled, databaseStep.runCalled)
+	}
+
+	herdStep.runCalled = false
+	databaseStep.runCalled = false
+	if err := manager.RunCleanup(t.TempDir(), "branch", "repo", "site", "recording", cfg, false, false, true); err != nil {
+		t.Fatalf("RunCleanup() error = %v", err)
+	}
+	if !herdStep.runCalled || !databaseStep.runCalled {
+		t.Fatalf("wrapper cleanup calls: herd=%v db.destroy=%v", herdStep.runCalled, databaseStep.runCalled)
+	}
+}
+
+func TestRunCleanupWithOptions_DryRunInvokesDbDestroyWithDryRun(t *testing.T) {
+	databaseStep := &mockStep{name: config.StepDbDestroy, conditionResult: true}
+	manager := NewScaffoldManagerWithRegistry(&cleanupRecordingRegistry{steps: map[string]*mockStep{
+		config.StepDbDestroy: databaseStep,
+	}})
+	manager.RegisterPreset(cleanupRecordingPreset{cleanup: []config.CleanupStep{{Name: config.StepDbDestroy}}})
+
+	err := manager.RunCleanupWithOptions(
+		t.TempDir(), "branch", "repo", "site", "recording", &config.Config{Preset: "recording"},
+		CleanupOptions{DryRun: true, Quiet: true},
+	)
+
+	if err != nil {
+		t.Fatalf("RunCleanupWithOptions() error = %v", err)
+	}
+	if len(databaseStep.runOptions) != 1 || !databaseStep.runOptions[0].DryRun {
+		t.Fatalf("db.destroy run options = %#v", databaseStep.runOptions)
+	}
+}
+
+func TestPrepareDbSuffixSetsProvenance(t *testing.T) {
+	t.Run("persisted suffix", func(t *testing.T) {
+		dir := t.TempDir()
+		if err := config.WriteLocalState(dir, config.LocalState{DbSuffix: "top_provider"}); err != nil {
+			t.Fatalf("WriteLocalState() error = %v", err)
+		}
+		ctx := &types.ScaffoldContext{WorktreePath: dir}
+		if err := prepareDbSuffix(ctx, dir, false); err != nil {
+			t.Fatalf("prepareDbSuffix() error = %v", err)
+		}
+		if ctx.GetDbSuffix() != "top_provider" || !ctx.DbSuffixFromState() {
+			t.Fatalf("persisted suffix state = %q, provenance=%v", ctx.GetDbSuffix(), ctx.DbSuffixFromState())
+		}
+	})
+
+	t.Run("fresh suffix", func(t *testing.T) {
+		dir := t.TempDir()
+		ctx := &types.ScaffoldContext{WorktreePath: dir}
+		if err := prepareDbSuffix(ctx, dir, false); err != nil {
+			t.Fatalf("prepareDbSuffix() error = %v", err)
+		}
+		if ctx.GetDbSuffix() == "" || ctx.DbSuffixFromState() {
+			t.Fatalf("fresh suffix state = %q, provenance=%v", ctx.GetDbSuffix(), ctx.DbSuffixFromState())
+		}
+	})
+}

--- a/internal/scaffold/steps/bash_run.go
+++ b/internal/scaffold/steps/bash_run.go
@@ -39,6 +39,9 @@ func (s *BashRunStep) Name() string {
 }
 
 func (s *BashRunStep) Run(ctx *types.ScaffoldContext, opts types.StepOptions) error {
+	if opts.DryRun {
+		return nil
+	}
 	command, err := template.ReplaceTemplateVars(s.command, ctx)
 	if err != nil {
 		return fmt.Errorf("template replacement failed: %w", err)

--- a/internal/scaffold/steps/binary.go
+++ b/internal/scaffold/steps/binary.go
@@ -49,13 +49,23 @@ func NewBinaryStepWithExecutor(name, binary string, args []string, storeAs strin
 // NewBinaryStepWithCondition creates a binary step with condition evaluation.
 // This is the factory function used by the registry.
 func NewBinaryStepWithCondition(name string, cfg config.StepConfig, binary string) *BinaryStep {
+	return NewBinaryStepWithConditionAndExecutor(name, cfg, binary, nil)
+}
+
+// NewBinaryStepWithConditionAndExecutor creates a conditional binary step with a custom command executor.
+// This is useful for testing conditional command execution without launching an operating-system process.
+func NewBinaryStepWithConditionAndExecutor(name string, cfg config.StepConfig, binary string, executor *anvil_exec.CommandExecutor) *BinaryStep {
+	if executor == nil {
+		executor = anvil_exec.NewCommandExecutor(nil)
+	}
+
 	return &BinaryStep{
 		name:      name,
 		binary:    binary,
 		args:      cfg.Args,
 		condition: cfg.Condition,
 		storeAs:   cfg.StoreAs,
-		executor:  anvil_exec.NewCommandExecutor(nil),
+		executor:  executor,
 	}
 }
 

--- a/internal/scaffold/steps/binary.go
+++ b/internal/scaffold/steps/binary.go
@@ -95,6 +95,9 @@ func (s *BinaryStep) Condition(ctx *types.ScaffoldContext) bool {
 }
 
 func (s *BinaryStep) Run(ctx *types.ScaffoldContext, opts types.StepOptions) error {
+	if opts.DryRun {
+		return nil
+	}
 	allArgs := append(s.args, opts.Args...)
 	allArgs = s.replaceTemplate(allArgs, ctx)
 	if opts.Verbose {

--- a/internal/scaffold/steps/cleanup_dry_run_test.go
+++ b/internal/scaffold/steps/cleanup_dry_run_test.go
@@ -1,0 +1,44 @@
+package steps
+
+import (
+	"testing"
+
+	anvilexec "github.com/naoray/anvil/internal/exec"
+	"github.com/naoray/anvil/internal/scaffold/types"
+)
+
+func TestCleanupCapableCommandSteps_DryRunDoesNotExecuteCommands(t *testing.T) {
+	tests := []struct {
+		name string
+		step types.ScaffoldStep
+		mock *anvilexec.MockCommander
+	}{
+		{
+			name: "binary",
+			mock: anvilexec.NewMockCommander(),
+		},
+		{
+			name: "bash",
+			mock: anvilexec.NewMockCommander(),
+		},
+		{
+			name: "command",
+			mock: anvilexec.NewMockCommander(),
+		},
+	}
+	tests[0].step = NewBinaryStepWithExecutor("herd", "herd", []string{"unlink"}, "", anvilexec.NewCommandExecutor(tests[0].mock))
+	tests[1].step = NewBashRunStepWithExecutor("echo mutate", "", anvilexec.NewCommandExecutor(tests[1].mock))
+	tests[2].step = NewCommandRunStepWithExecutor("echo mutate", "", anvilexec.NewCommandExecutor(tests[2].mock))
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.step.Run(&types.ScaffoldContext{WorktreePath: t.TempDir()}, types.StepOptions{DryRun: true})
+			if err != nil {
+				t.Fatalf("Run() error = %v", err)
+			}
+			if tt.mock.CallCount() != 0 {
+				t.Fatalf("command calls = %d, want 0", tt.mock.CallCount())
+			}
+		})
+	}
+}

--- a/internal/scaffold/steps/command_run.go
+++ b/internal/scaffold/steps/command_run.go
@@ -38,6 +38,9 @@ func (s *CommandRunStep) Name() string {
 }
 
 func (s *CommandRunStep) Run(ctx *types.ScaffoldContext, opts types.StepOptions) error {
+	if opts.DryRun {
+		return nil
+	}
 	// Use the command executor for testability
 	output, err := s.executor.RunShell(context.Background(), ctx.WorktreePath, s.command)
 	if err != nil {

--- a/internal/scaffold/steps/db.go
+++ b/internal/scaffold/steps/db.go
@@ -1,9 +1,12 @@
 package steps
 
 import (
+	"errors"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/naoray/anvil/internal/config"
 	"github.com/naoray/anvil/internal/scaffold/types"
@@ -42,6 +45,7 @@ type DbCreateStep struct {
 	name          string
 	args          []string
 	dbType        string
+	role          string
 	clientFactory DatabaseClientFactory
 }
 
@@ -50,6 +54,7 @@ func NewDbCreateStep(cfg config.StepConfig) *DbCreateStep {
 		name:          config.StepDbCreate,
 		args:          cfg.Args,
 		dbType:        cfg.Type,
+		role:          cfg.Role,
 		clientFactory: DefaultDatabaseClientFactory,
 	}
 }
@@ -59,6 +64,7 @@ func NewDbCreateStepWithFactory(cfg config.StepConfig, factory DatabaseClientFac
 		name:          config.StepDbCreate,
 		args:          cfg.Args,
 		dbType:        cfg.Type,
+		role:          cfg.Role,
 		clientFactory: factory,
 	}
 }
@@ -80,11 +86,25 @@ func (s *DbCreateStep) Run(ctx *types.ScaffoldContext, opts types.StepOptions) e
 		return nil
 	}
 
+	role := s.role
+	if role == "" {
+		role = config.DbRoleApplication
+	}
+	if role != config.DbRoleApplication && role != config.DbRoleTesting {
+		return fmt.Errorf("unsupported database role %q", role)
+	}
+
 	if opts.Verbose {
-		fmt.Printf("  Creating database (%s)...\n", engine)
+		fmt.Printf("  Creating %s database (%s)...\n", role, engine)
 	}
 
 	if engine == config.DBEngineSQLite {
+		if role == config.DbRoleTesting {
+			if opts.Verbose {
+				fmt.Printf("  SQLite databases are worktree-local files; skipping testing database creation.\n")
+			}
+			return nil
+		}
 		dbName := ""
 		for i, arg := range s.args {
 			if arg == "--database" && i+1 < len(s.args) {
@@ -101,6 +121,9 @@ func (s *DbCreateStep) Run(ctx *types.ScaffoldContext, opts types.StepOptions) e
 		return s.createSqlite(ctx, dbName, opts)
 	}
 
+	if role == config.DbRoleTesting {
+		return s.createTestDatabase(ctx, engine, opts)
+	}
 	return s.createWithRetry(ctx, engine, opts)
 }
 
@@ -148,7 +171,7 @@ func (s *DbCreateStep) parseConnectionOptions() DatabaseOptions {
 
 const maxDbCreateRetries = 5
 
-func (s *DbCreateStep) createWithRetry(ctx *types.ScaffoldContext, engine config.DatabaseEngine, opts types.StepOptions) error {
+func (s *DbCreateStep) createWithRetry(ctx *types.ScaffoldContext, engine config.DatabaseEngine, opts types.StepOptions) (runErr error) {
 	siteName := s.getPrefixOrSiteName(ctx)
 	dbOpts := s.parseConnectionOptions()
 
@@ -156,7 +179,7 @@ func (s *DbCreateStep) createWithRetry(ctx *types.ScaffoldContext, engine config
 	if err != nil {
 		return fmt.Errorf("creating database client: %w", err)
 	}
-	defer func() { _ = client.Close() }() // best-effort cleanup
+	defer func() { runErr = errors.Join(runErr, client.Close()) }()
 
 	if err := client.Ping(); err != nil {
 		if opts.Verbose {
@@ -189,16 +212,15 @@ func (s *DbCreateStep) createWithRetry(ctx *types.ScaffoldContext, engine config
 			if opts.Verbose {
 				fmt.Printf("  Database '%s' created successfully.\n", dbName)
 			}
-			if err := s.persistDbSuffix(ctx); err != nil {
-				if opts.Verbose {
-					fmt.Printf("  warning: failed to persist db_suffix: %v\n", err)
-				}
-			}
-			return nil
+			return s.persistOwnedDatabase(ctx, dbName, engine, config.DbRoleApplication)
 		}
 
 		if !IsDatabaseExistsError(err) {
 			return fmt.Errorf("failed to create database: %w", err)
+		}
+
+		if ctx.DbSuffixFromState() {
+			return s.persistOwnedDatabase(ctx, dbName, engine, config.DbRoleApplication)
 		}
 
 		if opts.Verbose {
@@ -211,14 +233,51 @@ func (s *DbCreateStep) createWithRetry(ctx *types.ScaffoldContext, engine config
 	return fmt.Errorf("failed to create database after %d attempts: %w", maxDbCreateRetries, lastErr)
 }
 
-func (s *DbCreateStep) persistDbSuffix(ctx *types.ScaffoldContext) error {
+func (s *DbCreateStep) createTestDatabase(ctx *types.ScaffoldContext, engine config.DatabaseEngine, opts types.StepOptions) (runErr error) {
 	suffix := ctx.GetDbSuffix()
 	if suffix == "" {
+		if opts.Verbose {
+			fmt.Printf("  No database suffix found, skipping testing database creation.\n")
+		}
 		return nil
 	}
 
-	// Write to .anvil.local instead of anvil.yaml
-	return config.WriteLocalState(ctx.WorktreePath, config.LocalState{DbSuffix: suffix})
+	dbName := words.BuildTestDatabaseName(s.getPrefixOrSiteName(ctx), suffix)
+	client, err := s.clientFactory(string(engine), s.parseConnectionOptions())
+	if err != nil {
+		return fmt.Errorf("creating database client: %w", err)
+	}
+	defer func() { runErr = errors.Join(runErr, client.Close()) }()
+
+	if err := client.Ping(); err != nil {
+		if opts.Verbose {
+			fmt.Printf("  Could not connect to %s database: %v\n", engine, err)
+		}
+		return nil
+	}
+	if opts.DryRun {
+		if opts.Verbose {
+			fmt.Printf("  Would create testing database: %s\n", dbName)
+		}
+		return nil
+	}
+
+	if err := client.CreateDatabase(dbName); err != nil && !IsDatabaseExistsError(err) {
+		return fmt.Errorf("failed to create testing database: %w", err)
+	}
+	return s.persistOwnedDatabase(ctx, dbName, engine, config.DbRoleTesting)
+}
+
+func (s *DbCreateStep) persistOwnedDatabase(ctx *types.ScaffoldContext, name string, engine config.DatabaseEngine, role string) error {
+	if err := config.WriteLocalState(ctx.WorktreePath, config.LocalState{
+		DbSuffix: ctx.GetDbSuffix(),
+		Databases: []config.OwnedDatabase{{
+			Name: name, Engine: string(engine), Role: role,
+		}},
+	}); err != nil {
+		return fmt.Errorf("recording ownership of database %q: %w", name, err)
+	}
+	return nil
 }
 
 func (s *DbCreateStep) createSqlite(ctx *types.ScaffoldContext, dbName string, opts types.StepOptions) error {
@@ -257,23 +316,31 @@ type DbDestroyStep struct {
 	args          []string
 	dbType        string
 	clientFactory DatabaseClientFactory
+	output        io.Writer
 }
 
 func NewDbDestroyStep(cfg config.StepConfig) *DbDestroyStep {
-	return &DbDestroyStep{
-		name:          config.StepDbDestroy,
-		args:          cfg.Args,
-		dbType:        cfg.Type,
-		clientFactory: DefaultDatabaseClientFactory,
-	}
+	return NewDbDestroyStepWithFactoryAndWriter(cfg, DefaultDatabaseClientFactory, os.Stdout)
 }
 
 func NewDbDestroyStepWithFactory(cfg config.StepConfig, factory DatabaseClientFactory) *DbDestroyStep {
+	return NewDbDestroyStepWithFactoryAndWriter(cfg, factory, os.Stdout)
+}
+
+func NewDbDestroyStepWithFactoryAndWriter(
+	cfg config.StepConfig,
+	factory DatabaseClientFactory,
+	output io.Writer,
+) *DbDestroyStep {
+	if output == nil {
+		output = os.Stdout
+	}
 	return &DbDestroyStep{
 		name:          config.StepDbDestroy,
 		args:          cfg.Args,
 		dbType:        cfg.Type,
 		clientFactory: factory,
+		output:        output,
 	}
 }
 
@@ -286,41 +353,40 @@ func (s *DbDestroyStep) Condition(ctx *types.ScaffoldContext) bool {
 }
 
 func (s *DbDestroyStep) Run(ctx *types.ScaffoldContext, opts types.StepOptions) error {
-	suffix := ctx.GetDbSuffix()
-	if suffix == "" {
-		localState, err := config.ReadLocalState(ctx.WorktreePath)
-		if err != nil {
-			return nil
-		}
-		suffix = localState.DbSuffix
+	localState, err := config.ReadLocalState(ctx.WorktreePath)
+	if err != nil {
+		return fmt.Errorf("reading local state for database cleanup: %w", err)
+	}
+	if len(localState.Databases) > 0 {
+		return s.destroyOwnedDatabases(localState.Databases, opts)
 	}
 
+	suffix := ctx.GetDbSuffix()
+	if suffix == "" {
+		suffix = localState.DbSuffix
+	}
 	if suffix == "" {
 		if opts.Verbose {
-			fmt.Printf("  No database suffix found, skipping cleanup.\n")
+			return writeDatabaseCleanupOutput(s.output, "  No database suffix found, skipping cleanup.\n")
 		}
 		return nil
+	}
+	if !config.IsValidDatabaseIdentifier(suffix) {
+		return fmt.Errorf("invalid legacy database suffix %q", suffix)
 	}
 
 	ctx.SetDbSuffix(suffix)
-
 	engine, err := detectDatabaseEngine(s.dbType, ctx)
 	if err != nil {
 		if opts.Verbose {
-			fmt.Printf("  %v\n", err)
+			return writeDatabaseCleanupOutput(s.output, "  %v\n", err)
 		}
 		return nil
 	}
-
-	if opts.Verbose {
-		fmt.Printf("  Cleaning up databases matching suffix: %s\n", suffix)
-	}
-
 	if engine == config.DBEngineSQLite {
 		return nil
 	}
-
-	return s.destroyDatabases(engine, suffix, opts)
+	return s.destroyLegacyDatabases(engine, suffix, opts)
 }
 
 func (s *DbDestroyStep) parseConnectionOptions(engine config.DatabaseEngine) DatabaseOptions {
@@ -354,60 +420,170 @@ func (s *DbDestroyStep) parseConnectionOptions(engine config.DatabaseEngine) Dat
 	return opts
 }
 
-func (s *DbDestroyStep) destroyDatabases(engine config.DatabaseEngine, suffix string, opts types.StepOptions) error {
-	dbOpts := s.parseConnectionOptions(engine)
+type ownedTargetSelection struct {
+	engine   config.DatabaseEngine
+	exact    []string
+	families []config.OwnedDatabase
+}
 
-	client, err := s.clientFactory(string(engine), dbOpts)
-	if err != nil {
-		if opts.Verbose {
-			fmt.Printf("  Could not create database client: %v\n", err)
-		}
-		return nil
+func selectOwnedTargets(databases []config.OwnedDatabase) (ownedTargetSelection, error) {
+	if len(databases) == 0 {
+		return ownedTargetSelection{}, fmt.Errorf("no owned database records")
 	}
-	defer func() { _ = client.Close() }() // best-effort cleanup
+	if err := config.ValidateOwnedDatabases(databases); err != nil {
+		return ownedTargetSelection{}, fmt.Errorf("validating owned database records: %w", err)
+	}
+
+	selection := ownedTargetSelection{
+		engine:   config.DatabaseEngine(databases[0].Engine),
+		exact:    make([]string, 0, len(databases)),
+		families: append([]config.OwnedDatabase(nil), databases...),
+	}
+	seen := make(map[string]struct{}, len(databases))
+	for _, database := range databases {
+		if _, exists := seen[database.Name]; exists {
+			continue
+		}
+		seen[database.Name] = struct{}{}
+		selection.exact = append(selection.exact, database.Name)
+	}
+	return selection, nil
+}
+
+func (s *DbDestroyStep) destroyOwnedDatabases(databases []config.OwnedDatabase, opts types.StepOptions) (runErr error) {
+	selection, err := selectOwnedTargets(databases)
+	if err != nil {
+		return err
+	}
+
+	client, err := s.clientFactory(string(selection.engine), s.parseConnectionOptions(selection.engine))
+	if err != nil {
+		if opts.DryRun {
+			return errors.Join(
+				printDryRunTargets(s.output, selection.exact),
+				writeDatabaseCleanupOutput(s.output, "cannot enumerate parallel-worker databases: %v\n", err),
+			)
+		}
+		return fmt.Errorf("creating database cleanup client: %w", err)
+	}
+	defer func() { runErr = errors.Join(runErr, client.Close()) }()
 
 	if err := client.Ping(); err != nil {
-		if opts.Verbose {
-			fmt.Printf("  Could not connect to %s database: %v\n", engine, err)
-		}
-		return nil
-	}
-
-	pattern := fmt.Sprintf("%%_%s", suffix)
-	databases, err := client.ListDatabases(pattern)
-	if err != nil {
-		if opts.Verbose {
-			fmt.Printf("  Failed to list databases: %v\n", err)
-		}
-		return nil
-	}
-
-	if len(databases) == 0 {
-		if opts.Verbose {
-			fmt.Printf("  No databases matching pattern found.\n")
-		}
-		return nil
-	}
-
-	for _, dbName := range databases {
 		if opts.DryRun {
-			if opts.Verbose {
-				fmt.Printf("  Would drop database: %s\n", dbName)
+			return errors.Join(
+				printDryRunTargets(s.output, selection.exact),
+				writeDatabaseCleanupOutput(s.output, "cannot enumerate parallel-worker databases: %v\n", err),
+			)
+		}
+		return fmt.Errorf("connecting to %s for database cleanup: %w", selection.engine, err)
+	}
+
+	targets := append([]string(nil), selection.exact...)
+	seenTargets := make(map[string]struct{}, len(targets))
+	for _, target := range targets {
+		seenTargets[target] = struct{}{}
+	}
+	var runtimeErrors []error
+	for _, family := range selection.families {
+		pattern := EscapeLikePattern(family.Name) + `\_test\_%`
+		candidates, listErr := client.ListDatabases(pattern)
+		if listErr != nil {
+			if opts.DryRun {
+				if outputErr := writeDatabaseCleanupOutput(s.output, "cannot enumerate parallel-worker databases: %v\n", listErr); outputErr != nil {
+					runtimeErrors = append(runtimeErrors, outputErr)
+				}
+			} else {
+				runtimeErrors = append(runtimeErrors,
+					fmt.Errorf("listing parallel-worker databases for %q: %w", family.Name, listErr))
 			}
 			continue
 		}
-
-		if err := client.DropDatabase(dbName); err != nil {
-			if opts.Verbose {
-				fmt.Printf("  Failed to drop database %s: %v\n", dbName, err)
+		prefix := family.Name + "_test_"
+		for _, candidate := range candidates {
+			if !config.IsValidDatabaseIdentifier(candidate) || !strings.HasPrefix(candidate, prefix) {
+				continue
 			}
-			continue
-		}
-
-		if opts.Verbose {
-			fmt.Printf("  Dropped database: %s\n", dbName)
+			if _, exists := seenTargets[candidate]; exists {
+				continue
+			}
+			seenTargets[candidate] = struct{}{}
+			targets = append(targets, candidate)
 		}
 	}
 
+	if opts.DryRun {
+		return errors.Join(append(runtimeErrors, printDryRunTargets(s.output, targets))...)
+	}
+	runtimeErrors = append(runtimeErrors, dropDatabaseTargets(client, targets, opts, s.output)...)
+	return errors.Join(runtimeErrors...)
+}
+
+func (s *DbDestroyStep) destroyLegacyDatabases(engine config.DatabaseEngine, suffix string, opts types.StepOptions) (runErr error) {
+	client, err := s.clientFactory(string(engine), s.parseConnectionOptions(engine))
+	if err != nil {
+		if opts.DryRun {
+			return writeDatabaseCleanupOutput(s.output, "cannot enumerate parallel-worker databases: %v\n", err)
+		}
+		return fmt.Errorf("creating legacy database cleanup client: %w", err)
+	}
+	defer func() { runErr = errors.Join(runErr, client.Close()) }()
+
+	if err := client.Ping(); err != nil {
+		if opts.DryRun {
+			return writeDatabaseCleanupOutput(s.output, "cannot enumerate parallel-worker databases: %v\n", err)
+		}
+		return fmt.Errorf("connecting to %s for legacy database cleanup: %w", engine, err)
+	}
+
+	pattern := `%\_` + EscapeLikePattern(suffix)
+	candidates, err := client.ListDatabases(pattern)
+	if err != nil {
+		if opts.DryRun {
+			return writeDatabaseCleanupOutput(s.output, "cannot enumerate parallel-worker databases: %v\n", err)
+		}
+		return fmt.Errorf("listing legacy databases for suffix %q: %w", suffix, err)
+	}
+	targets := make([]string, 0, len(candidates))
+	for _, candidate := range candidates {
+		if config.IsValidDatabaseIdentifier(candidate) && strings.HasSuffix(candidate, "_"+suffix) {
+			targets = append(targets, candidate)
+		}
+	}
+	if opts.DryRun {
+		return printDryRunTargets(s.output, targets)
+	}
+	return errors.Join(dropDatabaseTargets(client, targets, opts, s.output)...)
+}
+
+func dropDatabaseTargets(client DatabaseClient, targets []string, opts types.StepOptions, output io.Writer) []error {
+	var dropErrors []error
+	for _, database := range targets {
+		if err := client.DropDatabase(database); err != nil {
+			dropErrors = append(dropErrors, fmt.Errorf("dropping database %q: %w", database, err))
+			continue
+		}
+		if opts.Verbose {
+			if err := writeDatabaseCleanupOutput(output, "  Dropped database: %s\n", database); err != nil {
+				dropErrors = append(dropErrors, err)
+			}
+		}
+	}
+	return dropErrors
+}
+
+func printDryRunTargets(output io.Writer, targets []string) error {
+	var outputErrors []error
+	for _, database := range targets {
+		if err := writeDatabaseCleanupOutput(output, "Would drop database: %s\n", database); err != nil {
+			outputErrors = append(outputErrors, err)
+		}
+	}
+	return errors.Join(outputErrors...)
+}
+
+func writeDatabaseCleanupOutput(output io.Writer, format string, args ...any) error {
+	if _, err := fmt.Fprintf(output, format, args...); err != nil {
+		return fmt.Errorf("writing database cleanup output: %w", err)
+	}
 	return nil
 }

--- a/internal/scaffold/steps/db_destroy_owned_test.go
+++ b/internal/scaffold/steps/db_destroy_owned_test.go
@@ -1,0 +1,196 @@
+package steps
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/naoray/anvil/internal/config"
+	"github.com/naoray/anvil/internal/scaffold/types"
+)
+
+func TestDbDestroyStep_InvalidOwnedStateFailsClosed(t *testing.T) {
+	tests := []struct {
+		name string
+		dbs  []config.OwnedDatabase
+		want string
+	}{
+		{"unknown role", []config.OwnedDatabase{
+			{Name: "app", Engine: "pgsql", Role: config.DbRoleApplication},
+			{Name: "weird", Engine: "pgsql", Role: "someday-role"},
+		}, "unsupported database record role"},
+		{"unknown engine", []config.OwnedDatabase{
+			{Name: "app", Engine: "oracle", Role: config.DbRoleApplication},
+		}, "unsupported database engine"},
+		{"mixed engines", []config.OwnedDatabase{
+			{Name: "app", Engine: "mysql", Role: config.DbRoleApplication},
+			{Name: "app_test", Engine: "pgsql", Role: config.DbRoleTesting},
+		}, "exactly one supported engine"},
+		{"invalid name", []config.OwnedDatabase{
+			{Name: "bad;drop", Engine: "mysql", Role: config.DbRoleApplication},
+		}, "invalid database name"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := t.TempDir()
+			writeOwnedState(t, dir, tt.dbs)
+			client := NewMockDatabaseClient()
+			factory := NewMockClientFactoryRecorder(client)
+			step := NewDbDestroyStepWithFactory(config.StepConfig{}, factory.Factory)
+
+			err := step.Run(&types.ScaffoldContext{WorktreePath: dir}, types.StepOptions{})
+			require.Error(t, err)
+			assert.ErrorContains(t, err, tt.want)
+			assert.Equal(t, 0, factory.CallCount())
+			assert.Empty(t, client.GetListCalls())
+			assert.Empty(t, client.GetDropCalls())
+		})
+	}
+}
+
+func TestDbDestroyStep_InvalidOwnedStateAggregatesEveryViolation(t *testing.T) {
+	dir := t.TempDir()
+	writeOwnedState(t, dir, []config.OwnedDatabase{
+		{Name: "bad;first", Engine: "mysql", Role: "someday-role"},
+		{Name: "second", Engine: "oracle", Role: config.DbRoleTesting},
+		{Name: "third", Engine: "pgsql", Role: config.DbRoleApplication},
+	})
+	factory := NewMockClientFactoryRecorder(NewMockDatabaseClient())
+	step := NewDbDestroyStepWithFactory(config.StepConfig{}, factory.Factory)
+	err := step.Run(&types.ScaffoldContext{WorktreePath: dir}, types.StepOptions{})
+	require.Error(t, err)
+	for _, want := range []string{"bad;first", "someday-role", "second", "oracle", "exactly one supported engine"} {
+		assert.ErrorContains(t, err, want)
+	}
+	assert.Equal(t, 0, factory.CallCount())
+}
+
+func TestDbDestroyStep_OwnedStateDropsExactAndBothWorkerFamilies(t *testing.T) {
+	dir := t.TempDir()
+	app := "dashboard_top_provider"
+	testDB := "dashboard_top_provider_test"
+	writeOwnedState(t, dir, []config.OwnedDatabase{
+		{Name: app, Engine: "mysql", Role: config.DbRoleApplication},
+		{Name: testDB, Engine: "mysql", Role: config.DbRoleTesting},
+	})
+	client := NewMockDatabaseClient()
+	for _, name := range []string{
+		app, testDB,
+		testDB + "_1",
+		testDB + "_test_1",
+		testDB + "_test_2",
+		"dashboard_top_provider2",
+		"dashboard_atop_provider",
+	} {
+		client.AddDatabase(name)
+	}
+	step := NewDbDestroyStepWithFactory(config.StepConfig{}, MockClientFactory(client))
+	require.NoError(t, step.Run(&types.ScaffoldContext{WorktreePath: dir}, types.StepOptions{}))
+
+	assert.Equal(t, []string{
+		app,
+		testDB,
+		testDB + "_1",
+		testDB + "_test_1",
+		testDB + "_test_2",
+	}, client.GetDropCalls())
+	assert.Equal(t, []string{
+		EscapeLikePattern(app) + `\_test\_%`,
+		EscapeLikePattern(testDB) + `\_test\_%`,
+	}, client.GetListCalls())
+	assert.True(t, client.HasDatabase("dashboard_top_provider2"))
+	assert.True(t, client.HasDatabase("dashboard_atop_provider"))
+}
+
+func TestDbDestroyStep_WorkerCandidatesPrefixRevalidated(t *testing.T) {
+	dir := t.TempDir()
+	app := "app_top_provider"
+	writeOwnedState(t, dir, []config.OwnedDatabase{{
+		Name: app, Engine: "pgsql", Role: config.DbRoleApplication,
+	}})
+	client := NewMockDatabaseClient()
+	pattern := EscapeLikePattern(app) + `\_test\_%`
+	client.SetListResultsForPattern(pattern, []string{
+		app + "_test_1",
+		"evil;name",
+		"unrelated_db",
+	})
+	step := NewDbDestroyStepWithFactory(config.StepConfig{}, MockClientFactory(client))
+	require.NoError(t, step.Run(&types.ScaffoldContext{WorktreePath: dir}, types.StepOptions{}))
+	assert.Equal(t, []string{app, app + "_test_1"}, client.GetDropCalls())
+}
+
+func TestDbDestroyStep_RuntimeErrorsAggregatedNotSwallowed(t *testing.T) {
+	dir := t.TempDir()
+	app := "app_top_provider"
+	testDB := "app_top_provider_test"
+	writeOwnedState(t, dir, []config.OwnedDatabase{
+		{Name: app, Engine: "mysql", Role: config.DbRoleApplication},
+		{Name: testDB, Engine: "mysql", Role: config.DbRoleTesting},
+	})
+	listErr := errors.New("list app workers")
+	dropErr := errors.New("drop app")
+	closeErr := errors.New("close client")
+	client := NewMockDatabaseClient()
+	client.SetListErrorForPattern(EscapeLikePattern(app)+`\_test\_%`, listErr)
+	client.SetDropErrorForDatabase(app, dropErr)
+	client.SetCloseError(closeErr)
+	step := NewDbDestroyStepWithFactory(config.StepConfig{}, MockClientFactory(client))
+
+	err := step.Run(&types.ScaffoldContext{WorktreePath: dir}, types.StepOptions{})
+	require.Error(t, err)
+	assert.ErrorIs(t, err, listErr)
+	assert.ErrorIs(t, err, dropErr)
+	assert.ErrorIs(t, err, closeErr)
+	assert.Equal(t, []string{app, testDB}, client.GetDropCalls())
+}
+
+func TestDbDestroyStep_DryRunEnumeratesWithoutDrops(t *testing.T) {
+	dir := t.TempDir()
+	app := "app_top_provider"
+	writeOwnedState(t, dir, []config.OwnedDatabase{{
+		Name: app, Engine: "mysql", Role: config.DbRoleApplication,
+	}})
+	client := NewMockDatabaseClient()
+	client.AddDatabase(app + "_test_1")
+	step := NewDbDestroyStepWithFactory(config.StepConfig{}, MockClientFactory(client))
+	require.NoError(t, step.Run(&types.ScaffoldContext{WorktreePath: dir}, types.StepOptions{DryRun: true}))
+	assert.Empty(t, client.GetDropCalls())
+	assert.NotEmpty(t, client.GetListCalls())
+}
+
+func TestDbDestroyStep_LegacyStateEscapedAndValidated(t *testing.T) {
+	t.Run("escaped suffix and returned names", func(t *testing.T) {
+		dir := t.TempDir()
+		require.NoError(t, config.WriteLocalState(dir, config.LocalState{DbSuffix: "top_provider"}))
+		client := NewMockDatabaseClient()
+		client.AddDatabase("dashboard_top_provider")
+		client.AddDatabase("dashboard_topXprovider")
+		step := NewDbDestroyStepWithFactory(config.StepConfig{Type: "mysql"}, MockClientFactory(client))
+		require.NoError(t, step.Run(&types.ScaffoldContext{WorktreePath: dir}, types.StepOptions{}))
+		assert.Equal(t, []string{`%\_top\_provider`}, client.GetListCalls())
+		assert.Equal(t, []string{"dashboard_top_provider"}, client.GetDropCalls())
+	})
+
+	t.Run("invalid suffix fails before factory", func(t *testing.T) {
+		dir := t.TempDir()
+		require.NoError(t, config.WriteLocalState(dir, config.LocalState{DbSuffix: "bad;suffix"}))
+		factory := NewMockClientFactoryRecorder(NewMockDatabaseClient())
+		step := NewDbDestroyStepWithFactory(config.StepConfig{Type: "mysql"}, factory.Factory)
+		err := step.Run(&types.ScaffoldContext{WorktreePath: dir}, types.StepOptions{})
+		require.Error(t, err)
+		assert.Contains(t, strings.ToLower(err.Error()), "invalid")
+		assert.Equal(t, 0, factory.CallCount())
+	})
+}
+
+func writeOwnedState(t *testing.T, dir string, databases []config.OwnedDatabase) {
+	t.Helper()
+	require.NoError(t, config.WriteLocalState(dir, config.LocalState{
+		DbSuffix: "top_provider", Databases: databases,
+	}))
+}

--- a/internal/scaffold/steps/db_test.go
+++ b/internal/scaffold/steps/db_test.go
@@ -449,6 +449,147 @@ func TestDbCreateStep(t *testing.T) {
 	})
 }
 
+func TestDbCreateStep_TestingRoleCreatesDerivedDatabaseAndPersists(t *testing.T) {
+	dir := t.TempDir()
+	client := NewMockDatabaseClient()
+	step := NewDbCreateStepWithFactory(config.StepConfig{
+		Type: "mysql",
+		Role: config.DbRoleTesting,
+	}, MockClientFactory(client))
+	ctx := &types.ScaffoldContext{WorktreePath: dir, SiteName: "Dashboard"}
+	ctx.SetDbSuffix("top_provider")
+
+	if err := step.Run(ctx, types.StepOptions{}); err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	assert.Equal(t, []string{"dashboard_top_provider_test"}, client.GetCreateCalls())
+	state, err := config.ReadLocalState(dir)
+	require.NoError(t, err)
+	require.Len(t, state.Databases, 1)
+	assert.Equal(t, config.OwnedDatabase{
+		Name: "dashboard_top_provider_test", Engine: "mysql", Role: config.DbRoleTesting,
+	}, state.Databases[0])
+	assert.Equal(t, "top_provider", state.DbSuffix)
+}
+
+func TestDbCreateStep_TestingRoleExistsIsSuccessNoRotationPGContract(t *testing.T) {
+	dir := t.TempDir()
+	client := NewMockDatabaseClient()
+	client.AddDatabase("dashboard_top_provider_test")
+	step := NewDbCreateStepWithFactory(config.StepConfig{
+		Type: "pgsql",
+		Role: config.DbRoleTesting,
+	}, MockClientFactory(client))
+	ctx := &types.ScaffoldContext{WorktreePath: dir, SiteName: "Dashboard"}
+	ctx.SetDbSuffix("top_provider")
+
+	if err := step.Run(ctx, types.StepOptions{}); err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	assert.Equal(t, "top_provider", ctx.GetDbSuffix())
+	assert.Equal(t, []string{"dashboard_top_provider_test"}, client.GetCreateCalls())
+	state, err := config.ReadLocalState(dir)
+	require.NoError(t, err)
+	require.Len(t, state.Databases, 1)
+	assert.Equal(t, "dashboard_top_provider_test", state.Databases[0].Name)
+}
+
+func TestDbCreateStep_TestingRoleNoSuffixOrSQLiteSkips(t *testing.T) {
+	t.Run("no suffix", func(t *testing.T) {
+		client := NewMockDatabaseClient()
+		step := NewDbCreateStepWithFactory(config.StepConfig{
+			Type: "mysql",
+			Role: config.DbRoleTesting,
+		}, MockClientFactory(client))
+		ctx := &types.ScaffoldContext{WorktreePath: t.TempDir(), SiteName: "Dashboard"}
+		require.NoError(t, step.Run(ctx, types.StepOptions{}))
+		assert.Empty(t, client.GetCreateCalls())
+	})
+
+	t.Run("sqlite", func(t *testing.T) {
+		dir := t.TempDir()
+		client := NewMockDatabaseClient()
+		step := NewDbCreateStepWithFactory(config.StepConfig{
+			Type: "sqlite",
+			Role: config.DbRoleTesting,
+		}, MockClientFactory(client))
+		ctx := &types.ScaffoldContext{WorktreePath: dir, SiteName: "Dashboard"}
+		ctx.SetDbSuffix("top_provider")
+		require.NoError(t, step.Run(ctx, types.StepOptions{}))
+		assert.Empty(t, client.GetCreateCalls())
+		assert.NoFileExists(t, filepath.Join(dir, "database", "database.sqlite"))
+	})
+}
+
+func TestDbCreateStep_ApplicationRolePersistsOwnedDatabase(t *testing.T) {
+	dir := t.TempDir()
+	client := NewMockDatabaseClient()
+	step := NewDbCreateStepWithFactory(config.StepConfig{Type: "mysql"}, MockClientFactory(client))
+	ctx := &types.ScaffoldContext{WorktreePath: dir, SiteName: "Dashboard"}
+	ctx.SetDbSuffix("top_provider")
+
+	require.NoError(t, step.Run(ctx, types.StepOptions{}))
+	state, err := config.ReadLocalState(dir)
+	require.NoError(t, err)
+	require.Len(t, state.Databases, 1)
+	assert.Equal(t, config.OwnedDatabase{
+		Name: "dashboard_top_provider", Engine: "mysql", Role: config.DbRoleApplication,
+	}, state.Databases[0])
+}
+
+func TestDbCreateStep_BothRolesPersistenceFailureIsHardError(t *testing.T) {
+	for _, role := range []string{config.DbRoleApplication, config.DbRoleTesting} {
+		t.Run(role, func(t *testing.T) {
+			parent := t.TempDir()
+			worktreePath := filepath.Join(parent, "not-a-directory")
+			require.NoError(t, os.WriteFile(worktreePath, []byte("file"), 0o644))
+			client := NewMockDatabaseClient()
+			step := NewDbCreateStepWithFactory(config.StepConfig{
+				Type: "mysql",
+				Role: role,
+			}, MockClientFactory(client))
+			ctx := &types.ScaffoldContext{WorktreePath: worktreePath, SiteName: "Dashboard"}
+			ctx.SetDbSuffix("top_provider")
+
+			err := step.Run(ctx, types.StepOptions{})
+			require.Error(t, err)
+			assert.ErrorContains(t, err, "recording ownership")
+		})
+	}
+}
+
+func TestCreateWithRetry_ExistsOnPersistedSuffixIdempotentNoRotationPGContract(t *testing.T) {
+	dir := t.TempDir()
+	client := NewMockDatabaseClient()
+	client.AddDatabase("dashboard_top_provider")
+	step := NewDbCreateStepWithFactory(config.StepConfig{Type: "pgsql"}, MockClientFactory(client))
+	ctx := &types.ScaffoldContext{WorktreePath: dir, SiteName: "Dashboard"}
+	ctx.SetDbSuffix("top_provider")
+	ctx.SetDbSuffixLoadedFromState()
+
+	require.NoError(t, step.Run(ctx, types.StepOptions{}))
+	assert.Equal(t, "top_provider", ctx.GetDbSuffix())
+	assert.Equal(t, []string{"dashboard_top_provider"}, client.GetCreateCalls())
+	state, err := config.ReadLocalState(dir)
+	require.NoError(t, err)
+	require.Len(t, state.Databases, 1)
+	assert.Equal(t, "dashboard_top_provider", state.Databases[0].Name)
+}
+
+func TestCreateWithRetry_ExistsOnFreshSuffixStillRotates(t *testing.T) {
+	dir := t.TempDir()
+	client := NewMockDatabaseClient()
+	client.AddDatabase("dashboard_collision")
+	step := NewDbCreateStepWithFactory(config.StepConfig{Type: "pgsql"}, MockClientFactory(client))
+	ctx := &types.ScaffoldContext{WorktreePath: dir, SiteName: "Dashboard"}
+	ctx.SetDbSuffix("collision")
+
+	require.NoError(t, step.Run(ctx, types.StepOptions{}))
+	assert.NotEqual(t, "collision", ctx.GetDbSuffix())
+	assert.Len(t, client.GetCreateCalls(), 2)
+	assert.Equal(t, "dashboard_collision", client.GetCreateCalls()[0])
+}
+
 func TestDbDestroyStep(t *testing.T) {
 	t.Run("name returns db.destroy", func(t *testing.T) {
 		step := NewDbDestroyStep(config.StepConfig{})
@@ -505,9 +646,9 @@ func TestDbDestroyStep(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Equal(t, "swift_runner", ctx.GetDbSuffix(), "DbSuffix should be read from local state")
 
-		listCalls := mockClient.listCalls
+		listCalls := mockClient.GetListCalls()
 		assert.Len(t, listCalls, 1)
-		assert.Equal(t, "%_swift_runner", listCalls[0])
+		assert.Equal(t, `%\_swift\_runner`, listCalls[0])
 	})
 
 	t.Run("drops databases matching suffix", func(t *testing.T) {
@@ -627,12 +768,12 @@ func TestDbDestroyStep(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Equal(t, "context_suffix", ctx.GetDbSuffix(), "Should use DbSuffix from context, not local state")
 
-		listCalls := mockClient.listCalls
+		listCalls := mockClient.GetListCalls()
 		assert.Len(t, listCalls, 1)
-		assert.Equal(t, "%_context_suffix", listCalls[0], "Should search with context suffix")
+		assert.Equal(t, `%\_context\_suffix`, listCalls[0], "Should search with escaped context suffix")
 	})
 
-	t.Run("skips when database ping fails", func(t *testing.T) {
+	t.Run("returns database ping failure", func(t *testing.T) {
 		tmpDir := t.TempDir()
 
 		envFile := filepath.Join(tmpDir, ".env")
@@ -650,7 +791,7 @@ func TestDbDestroyStep(t *testing.T) {
 		ctx.SetDbSuffix("test_suffix")
 
 		err := step.Run(ctx, types.StepOptions{Verbose: false})
-		assert.NoError(t, err, "Should not error when ping fails, just skip")
+		assert.ErrorContains(t, err, "connection refused")
 	})
 
 	t.Run("skips sqlite engine", func(t *testing.T) {

--- a/internal/scaffold/steps/dbclient.go
+++ b/internal/scaffold/steps/dbclient.go
@@ -2,7 +2,9 @@ package steps
 
 import (
 	"database/sql"
+	"errors"
 	"fmt"
+	"sort"
 	"strings"
 
 	_ "github.com/go-sql-driver/mysql"
@@ -29,6 +31,33 @@ type DatabaseOptions struct {
 	Port     string
 	Username string
 	Password string
+}
+
+const (
+	mysqlListDatabasesQuery    = "SELECT SCHEMA_NAME FROM information_schema.SCHEMATA WHERE SCHEMA_NAME LIKE ?"
+	postgresListDatabasesQuery = "SELECT datname FROM pg_database WHERE datname LIKE $1 AND datistemplate = false"
+)
+
+type databaseRows interface {
+	Next() bool
+	Scan(dest ...any) error
+	Err() error
+	Close() error
+}
+
+type databaseQueryer interface {
+	Query(query string, args ...any) (*sql.Rows, error)
+}
+
+// EscapeLikePattern escapes literal characters that SQL LIKE treats as
+// metacharacters. Callers add only the wildcards they intentionally need.
+func EscapeLikePattern(pattern string) string {
+	replacer := strings.NewReplacer(
+		`\`, `\\`,
+		"%", `\%`,
+		"_", `\_`,
+	)
+	return replacer.Replace(pattern)
 }
 
 // DefaultDatabaseClientFactory creates real database clients
@@ -97,22 +126,7 @@ func (c *MySQLClient) DropDatabase(name string) error {
 }
 
 func (c *MySQLClient) ListDatabases(pattern string) ([]string, error) {
-	query := fmt.Sprintf("SHOW DATABASES LIKE '%s'", pattern)
-	rows, err := c.db.Query(query)
-	if err != nil {
-		return nil, fmt.Errorf("listing databases: %w", err)
-	}
-	defer func() { _ = rows.Close() }() // best-effort cleanup
-
-	var databases []string
-	for rows.Next() {
-		var name string
-		if err := rows.Scan(&name); err != nil {
-			return nil, fmt.Errorf("scanning database name: %w", err)
-		}
-		databases = append(databases, name)
-	}
-	return databases, rows.Err()
+	return queryDatabaseNames(c.db, mysqlListDatabasesQuery, pattern)
 }
 
 // PostgreSQLClient implements DatabaseClient for PostgreSQL
@@ -182,22 +196,36 @@ func (c *PostgreSQLClient) DropDatabase(name string) error {
 }
 
 func (c *PostgreSQLClient) ListDatabases(pattern string) ([]string, error) {
-	query := "SELECT datname FROM pg_database WHERE datname LIKE $1 AND datistemplate = false"
-	rows, err := c.db.Query(query, pattern)
+	return queryDatabaseNames(c.db, postgresListDatabasesQuery, pattern)
+}
+
+func queryDatabaseNames(queryer databaseQueryer, query, pattern string) ([]string, error) {
+	rows, err := queryer.Query(query, pattern)
 	if err != nil {
 		return nil, fmt.Errorf("listing databases: %w", err)
 	}
-	defer func() { _ = rows.Close() }() // best-effort cleanup
+	return collectDatabaseNames(rows)
+}
 
-	var databases []string
+func collectDatabaseNames(rows databaseRows) (databases []string, err error) {
+	defer func() {
+		if closeErr := rows.Close(); closeErr != nil {
+			err = errors.Join(err, fmt.Errorf("closing database rows: %w", closeErr))
+		}
+	}()
 	for rows.Next() {
 		var name string
-		if err := rows.Scan(&name); err != nil {
-			return nil, fmt.Errorf("scanning database name: %w", err)
+		if scanErr := rows.Scan(&name); scanErr != nil {
+			err = errors.Join(err, fmt.Errorf("scanning database name: %w", scanErr))
+			break
 		}
 		databases = append(databases, name)
 	}
-	return databases, rows.Err()
+	if rowsErr := rows.Err(); rowsErr != nil {
+		err = errors.Join(err, fmt.Errorf("iterating database names: %w", rowsErr))
+	}
+	sort.Strings(databases)
+	return databases, err
 }
 
 // DatabaseExistsError indicates a database already exists

--- a/internal/scaffold/steps/dbclient_mock.go
+++ b/internal/scaffold/steps/dbclient_mock.go
@@ -1,40 +1,57 @@
 package steps
 
 import (
+	"regexp"
+	"sort"
+	"strings"
 	"sync"
 )
 
-// MockDatabaseClient implements DatabaseClient for testing
+// MockDatabaseClient implements DatabaseClient for testing.
 type MockDatabaseClient struct {
-	mu           sync.Mutex
-	databases    map[string]bool
-	createCalls  []string
-	dropCalls    []string
-	listCalls    []string
-	pingError    error
-	createError  error
-	dropError    error
-	listError    error
+	mu sync.Mutex
+
+	databases   map[string]bool
+	createCalls []string
+	dropCalls   []string
+	listCalls   []string
+
+	pingError   error
+	createError error
+	dropError   error
+	listError   error
+	closeError  error
+
+	dropErrors  map[string]error
+	listErrors  map[string]error
+	listResults map[string][]string
+
 	existsOnCall int
 	callCount    int
 }
 
-// NewMockDatabaseClient creates a new mock database client
 func NewMockDatabaseClient() *MockDatabaseClient {
 	return &MockDatabaseClient{
 		databases:   make(map[string]bool),
 		createCalls: make([]string, 0),
 		dropCalls:   make([]string, 0),
 		listCalls:   make([]string, 0),
+		dropErrors:  make(map[string]error),
+		listErrors:  make(map[string]error),
+		listResults: make(map[string][]string),
 	}
 }
 
 func (m *MockDatabaseClient) Ping() error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
 	return m.pingError
 }
 
 func (m *MockDatabaseClient) Close() error {
-	return nil
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.closeError
 }
 
 func (m *MockDatabaseClient) CreateDatabase(name string) error {
@@ -43,19 +60,15 @@ func (m *MockDatabaseClient) CreateDatabase(name string) error {
 
 	m.createCalls = append(m.createCalls, name)
 	m.callCount++
-
 	if m.createError != nil {
 		return m.createError
 	}
-
 	if m.existsOnCall > 0 && m.callCount <= m.existsOnCall {
 		return &DatabaseExistsError{Name: name}
 	}
-
 	if m.databases[name] {
 		return &DatabaseExistsError{Name: name}
 	}
-
 	m.databases[name] = true
 	return nil
 }
@@ -65,11 +78,12 @@ func (m *MockDatabaseClient) DropDatabase(name string) error {
 	defer m.mu.Unlock()
 
 	m.dropCalls = append(m.dropCalls, name)
-
+	if err := m.dropErrors[name]; err != nil {
+		return err
+	}
 	if m.dropError != nil {
 		return m.dropError
 	}
-
 	delete(m.databases, name)
 	return nil
 }
@@ -79,35 +93,105 @@ func (m *MockDatabaseClient) ListDatabases(pattern string) ([]string, error) {
 	defer m.mu.Unlock()
 
 	m.listCalls = append(m.listCalls, pattern)
-
+	if err := m.listErrors[pattern]; err != nil {
+		return nil, err
+	}
 	if m.listError != nil {
 		return nil, m.listError
 	}
-
-	var result []string
-	for name := range m.databases {
-		result = append(result, name)
+	if scripted, ok := m.listResults[pattern]; ok {
+		return append([]string(nil), scripted...), nil
 	}
+
+	result := make([]string, 0)
+	for name := range m.databases {
+		if likePatternMatches(pattern, name) {
+			result = append(result, name)
+		}
+	}
+	sort.Strings(result)
 	return result, nil
 }
 
+func likePatternMatches(pattern, value string) bool {
+	var expression strings.Builder
+	expression.WriteString("^")
+	escaped := false
+	for _, character := range pattern {
+		if escaped {
+			expression.WriteString(regexp.QuoteMeta(string(character)))
+			escaped = false
+			continue
+		}
+		switch character {
+		case '\\':
+			escaped = true
+		case '%':
+			expression.WriteString(".*")
+		case '_':
+			expression.WriteString(".")
+		default:
+			expression.WriteString(regexp.QuoteMeta(string(character)))
+		}
+	}
+	if escaped {
+		expression.WriteString(regexp.QuoteMeta(`\`))
+	}
+	expression.WriteString("$")
+	return regexp.MustCompile(expression.String()).MatchString(value)
+}
+
 func (m *MockDatabaseClient) SetPingError(err error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
 	m.pingError = err
 }
 
 func (m *MockDatabaseClient) SetCreateError(err error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
 	m.createError = err
 }
 
 func (m *MockDatabaseClient) SetDropError(err error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
 	m.dropError = err
 }
 
+func (m *MockDatabaseClient) SetDropErrorForDatabase(name string, err error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.dropErrors[name] = err
+}
+
 func (m *MockDatabaseClient) SetListError(err error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
 	m.listError = err
 }
 
+func (m *MockDatabaseClient) SetListErrorForPattern(pattern string, err error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.listErrors[pattern] = err
+}
+
+func (m *MockDatabaseClient) SetListResultsForPattern(pattern string, names []string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.listResults[pattern] = append([]string(nil), names...)
+}
+
+func (m *MockDatabaseClient) SetCloseError(err error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.closeError = err
+}
+
 func (m *MockDatabaseClient) SetExistsOnFirstNCalls(n int) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
 	m.existsOnCall = n
 }
 
@@ -120,17 +204,19 @@ func (m *MockDatabaseClient) AddDatabase(name string) {
 func (m *MockDatabaseClient) GetCreateCalls() []string {
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	result := make([]string, len(m.createCalls))
-	copy(result, m.createCalls)
-	return result
+	return append([]string(nil), m.createCalls...)
 }
 
 func (m *MockDatabaseClient) GetDropCalls() []string {
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	result := make([]string, len(m.dropCalls))
-	copy(result, m.dropCalls)
-	return result
+	return append([]string(nil), m.dropCalls...)
+}
+
+func (m *MockDatabaseClient) GetListCalls() []string {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return append([]string(nil), m.listCalls...)
 }
 
 func (m *MockDatabaseClient) HasDatabase(name string) bool {
@@ -145,9 +231,41 @@ func (m *MockDatabaseClient) DatabaseCount() int {
 	return len(m.databases)
 }
 
-// MockClientFactory creates a factory that returns the provided mock client
 func MockClientFactory(client *MockDatabaseClient) DatabaseClientFactory {
 	return func(engine string, opts DatabaseOptions) (DatabaseClient, error) {
 		return client, nil
 	}
+}
+
+type MockClientFactoryRecorder struct {
+	mu     sync.Mutex
+	client DatabaseClient
+	calls  int
+	err    error
+}
+
+func NewMockClientFactoryRecorder(client DatabaseClient) *MockClientFactoryRecorder {
+	return &MockClientFactoryRecorder{client: client}
+}
+
+func (r *MockClientFactoryRecorder) Factory(engine string, opts DatabaseOptions) (DatabaseClient, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.calls++
+	if r.err != nil {
+		return nil, r.err
+	}
+	return r.client, nil
+}
+
+func (r *MockClientFactoryRecorder) CallCount() int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.calls
+}
+
+func (r *MockClientFactoryRecorder) SetError(err error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.err = err
 }

--- a/internal/scaffold/steps/dbclient_test.go
+++ b/internal/scaffold/steps/dbclient_test.go
@@ -1,0 +1,109 @@
+package steps
+
+import (
+	"database/sql"
+	"errors"
+	"strings"
+	"testing"
+)
+
+func TestEscapeLikePattern(t *testing.T) {
+	if got, want := EscapeLikePattern("dashboard_top_provider_test"), `dashboard\_top\_provider\_test`; got != want {
+		t.Fatalf("EscapeLikePattern() = %q, want %q", got, want)
+	}
+	if got, want := EscapeLikePattern(`100%_a\b`), `100\%\_a\\b`; got != want {
+		t.Fatalf("EscapeLikePattern() = %q, want %q", got, want)
+	}
+}
+
+func TestListDatabases_RowsCloseErrorSurfaces(t *testing.T) {
+	closeErr := errors.New("close rows")
+	rows := &fakeDatabaseRows{names: []string{"b", "a"}, closeErr: closeErr}
+	names, err := collectDatabaseNames(rows)
+	if !errors.Is(err, closeErr) {
+		t.Fatalf("collectDatabaseNames() error = %v, want close error", err)
+	}
+	if strings.Join(names, ",") != "a,b" {
+		t.Fatalf("collectDatabaseNames() names = %v, want sorted names", names)
+	}
+}
+
+func TestListDatabases_RowErrAndCloseErrorBothReported(t *testing.T) {
+	rowErr := errors.New("iterate rows")
+	closeErr := errors.New("close rows")
+	rows := &fakeDatabaseRows{rowErr: rowErr, closeErr: closeErr}
+	_, err := collectDatabaseNames(rows)
+	if !errors.Is(err, rowErr) || !errors.Is(err, closeErr) {
+		t.Fatalf("collectDatabaseNames() error = %v, want both row and close errors", err)
+	}
+	message := err.Error()
+	if strings.Index(message, rowErr.Error()) > strings.Index(message, closeErr.Error()) {
+		t.Fatalf("row error must precede close error: %s", message)
+	}
+}
+
+func TestDatabaseListingsUseBoundPatternParameters(t *testing.T) {
+	for _, query := range []string{mysqlListDatabasesQuery, postgresListDatabasesQuery} {
+		t.Run(query, func(t *testing.T) {
+			queryErr := errors.New("stop after recording query")
+			recorder := &recordingDatabaseQueryer{err: queryErr}
+			_, err := queryDatabaseNames(recorder, query, `unsafe%'_pattern`)
+			if !errors.Is(err, queryErr) {
+				t.Fatalf("queryDatabaseNames() error = %v, want recorder error", err)
+			}
+			if recorder.query != query {
+				t.Fatalf("query = %q, want %q", recorder.query, query)
+			}
+			if len(recorder.args) != 1 || recorder.args[0] != `unsafe%'_pattern` {
+				t.Fatalf("query args = %#v, want one bound pattern", recorder.args)
+			}
+			if strings.Contains(recorder.query, `unsafe%'_pattern`) {
+				t.Fatalf("pattern was interpolated into query: %s", recorder.query)
+			}
+		})
+	}
+}
+
+type fakeDatabaseRows struct {
+	names    []string
+	index    int
+	rowErr   error
+	closeErr error
+}
+
+func (r *fakeDatabaseRows) Next() bool {
+	if r.index >= len(r.names) {
+		return false
+	}
+	r.index++
+	return true
+}
+
+func (r *fakeDatabaseRows) Scan(dest ...any) error {
+	value, ok := dest[0].(*string)
+	if !ok {
+		return errors.New("unexpected scan destination")
+	}
+	*value = r.names[r.index-1]
+	return nil
+}
+
+func (r *fakeDatabaseRows) Err() error {
+	return r.rowErr
+}
+
+func (r *fakeDatabaseRows) Close() error {
+	return r.closeErr
+}
+
+type recordingDatabaseQueryer struct {
+	query string
+	args  []any
+	err   error
+}
+
+func (q *recordingDatabaseQueryer) Query(query string, args ...any) (*sql.Rows, error) {
+	q.query = query
+	q.args = append([]any(nil), args...)
+	return nil, q.err
+}

--- a/internal/scaffold/types/types.go
+++ b/internal/scaffold/types/types.go
@@ -11,21 +11,23 @@ import (
 
 	"github.com/go-viper/mapstructure/v2"
 
+	"github.com/naoray/anvil/internal/scaffold/words"
 	"github.com/naoray/anvil/internal/utils"
 )
 
 type ScaffoldContext struct {
-	WorktreePath string
-	Branch       string
-	RepoName     string
-	SiteName     string
-	Preset       string
-	Env          map[string]string
-	Path         string
-	RepoPath     string
-	DbSuffix     string
-	Vars         map[string]string
-	mu           sync.RWMutex
+	WorktreePath      string
+	Branch            string
+	RepoName          string
+	SiteName          string
+	Preset            string
+	Env               map[string]string
+	Path              string
+	RepoPath          string
+	DbSuffix          string
+	Vars              map[string]string
+	dbSuffixFromState bool
+	mu                sync.RWMutex
 }
 
 type StepOptions struct {
@@ -353,6 +355,18 @@ func (ctx *ScaffoldContext) GetDbSuffix() string {
 	return ctx.DbSuffix
 }
 
+func (ctx *ScaffoldContext) SetDbSuffixLoadedFromState() {
+	ctx.mu.Lock()
+	defer ctx.mu.Unlock()
+	ctx.dbSuffixFromState = true
+}
+
+func (ctx *ScaffoldContext) DbSuffixFromState() bool {
+	ctx.mu.RLock()
+	defer ctx.mu.RUnlock()
+	return ctx.dbSuffixFromState
+}
+
 func (ctx *ScaffoldContext) SnapshotForTemplate() map[string]string {
 	ctx.mu.RLock()
 	defer ctx.mu.RUnlock()
@@ -361,8 +375,10 @@ func (ctx *ScaffoldContext) SnapshotForTemplate() map[string]string {
 
 	// Build a truncated database name that respects identifier limits.
 	var dbName string
+	var testDbName string
 	if ctx.DbSuffix != "" {
 		dbName = buildDatabaseName(sanitized, ctx.DbSuffix, maxDbNameLength)
+		testDbName = words.BuildTestDatabaseName(sanitized, ctx.DbSuffix)
 	}
 
 	snapshot := map[string]string{
@@ -374,6 +390,7 @@ func (ctx *ScaffoldContext) SnapshotForTemplate() map[string]string {
 		"Branch":            ctx.Branch,
 		"DbSuffix":          ctx.DbSuffix,
 		"DatabaseName":      dbName,
+		"TestDatabaseName":  testDbName,
 	}
 	for k, v := range ctx.Vars {
 		snapshot[k] = v

--- a/internal/scaffold/types/types_test.go
+++ b/internal/scaffold/types/types_test.go
@@ -632,6 +632,18 @@ func TestScaffoldContext_EnvExists_Array(t *testing.T) {
 	})
 }
 
+func TestSnapshotForTemplate_TestDatabaseName(t *testing.T) {
+	ctx := &ScaffoldContext{SiteName: "Dashboard", DbSuffix: "top_provider"}
+	if got := ctx.SnapshotForTemplate()["TestDatabaseName"]; got != "dashboard_top_provider_test" {
+		t.Fatalf("expected dashboard_top_provider_test, got %q", got)
+	}
+
+	empty := &ScaffoldContext{SiteName: "Dashboard"}
+	if got := empty.SnapshotForTemplate()["TestDatabaseName"]; got != "" {
+		t.Fatalf("expected empty testing database without suffix, got %q", got)
+	}
+}
+
 func TestScaffoldContext_CommandExists_Array(t *testing.T) {
 	tmpDir := t.TempDir()
 	ctx := &ScaffoldContext{

--- a/internal/scaffold/words/words.go
+++ b/internal/scaffold/words/words.go
@@ -33,8 +33,9 @@ var Nouns = []string{
 }
 
 const (
-	MaxDbNameLength = 63
-	SuffixMaxLength = 25
+	MaxDbNameLength     = 63
+	MaxTestDbNameLength = 54
+	SuffixMaxLength     = 25
 )
 
 func GenerateSuffix() string {
@@ -80,6 +81,12 @@ func BuildDatabaseName(siteName string, suffix string, maxLength int) string {
 	}
 
 	return fmt.Sprintf("%s_%s", sanitized, suffix)
+}
+
+// BuildTestDatabaseName reserves enough identifier headroom for Laravel's
+// "_test_<token>" parallel-worker suffix under PostgreSQL's 63-byte limit.
+func BuildTestDatabaseName(siteName string, suffix string) string {
+	return BuildDatabaseName(siteName, suffix+"_test", MaxTestDbNameLength)
 }
 
 func ExtractSuffix(dbName string) string {

--- a/internal/scaffold/words/words_test.go
+++ b/internal/scaffold/words/words_test.go
@@ -228,6 +228,28 @@ func TestBuildDatabaseName(t *testing.T) {
 	})
 }
 
+func TestBuildTestDatabaseName(t *testing.T) {
+	t.Run("derives testing database from worktree suffix", func(t *testing.T) {
+		name := BuildTestDatabaseName("dashboard", "top_provider")
+		if name != "dashboard_top_provider_test" {
+			t.Fatalf("expected dashboard_top_provider_test, got %q", name)
+		}
+	})
+
+	t.Run("reserves PostgreSQL worker suffix headroom", func(t *testing.T) {
+		name := BuildTestDatabaseName(strings.Repeat("a", 80), "top_provider")
+		if len(name) > MaxTestDbNameLength {
+			t.Fatalf("testing database name length %d exceeds %d: %s", len(name), MaxTestDbNameLength, name)
+		}
+		if !strings.HasSuffix(name, "_top_provider_test") {
+			t.Fatalf("testing database name lost suffix: %s", name)
+		}
+		if len(name+"_test_999") > MaxDbNameLength {
+			t.Fatalf("parallel worker name exceeds PostgreSQL limit: %s", name+"_test_999")
+		}
+	})
+}
+
 func TestMaxLengthEnforcement(t *testing.T) {
 	t.Run("respects PostgreSQL limit of 63", func(t *testing.T) {
 		name := GenerateDatabaseName("verylongsitenamethatdefinitelyexceedslimitsbyalot", 0)


### PR DESCRIPTION
## Summary

- clear PHPStan/Larastan result caches after Laravel environment updates
- create and track isolated application/testing databases per worktree
- add read-only `anvil exec`, ownership-aware cleanup, `--dry-run`, and `--keep-db`
- update the bundled Anvil agent skill for the v1.8 workflow
- harden release/changelog workflows and prepare v1.8.0

## Verification

- `go test ./... -count=1`
- `go test ./... -race -count=1`
- `go vet ./...`
- Windows build and vet
- golangci-lint v2.1.2 and v2.12.2
- skill-creator validation
- workflow hostile-payload and hermetic database endpoint regressions

Resolves solo todo #2322.
Resolves solo todo #2273.